### PR TITLE
Fix Changesets release PR generation by enabling package changelogs

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
-  "changelog": false,
+  "changelog": "@changesets/cli/changelog",
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -18,7 +18,7 @@
 3. Changesets가 Version Packages PR 생성
 4. Version Packages PR merge
 5. GitHub Actions가 변경된 npm 패키지만 `NPM_TOKEN` 으로 publish
-6. npm 패키지용 GitHub Release 는 만들지 않는다 (`.changeset/config.json` 이 `changelog: false` 이므로 `createGithubReleases: false` 유지)
+6. 패키지별 `CHANGELOG.md` 는 Changesets가 자동 관리하고, npm 패키지용 GitHub Release 는 계속 만들지 않는다 (`createGithubReleases: false` 유지)
 
 ## Python 패키지
 


### PR DESCRIPTION
## Summary
- enable the default Changesets changelog generator in `.changeset/config.json`
- keep npm GitHub Releases disabled while allowing `changesets/action` to build Version Packages PRs successfully
- update `docs/releasing.md` to match the new package changelog behavior

## Root cause
`changesets/action@v1` reads each changed package's `CHANGELOG.md` after `changeset version` runs. This repo had `changelog: false`, so versioning succeeded but the action crashed with `ENOENT` when it tried to read missing package changelogs.

## Verification
- `npm run version-packages`
- `npm run ci`