### PR TITLE
Fix CI: remove consumed changeset assertion

### DIFF
--- a/scripts/skill-docs.test.js
+++ b/scripts/skill-docs.test.js
@@ -998,19 +998,6 @@ test("pack:dry-run includes the toss-securities workspace", () => {
   assert.match(packageJson.scripts["pack:dry-run"], /workspace used-car-price-search/);
 });
 
-test("used-car-price-search ships with a changeset for release automation", () => {
-  const changesetDir = path.join(repoRoot, ".changeset");
-  const changesetFiles = fs
-    .readdirSync(changesetDir)
-    .filter((name) => name.endsWith(".md"))
-    .map((name) => read(path.join(".changeset", name)));
-
-  assert.ok(
-    changesetFiles.some((doc) => /["']used-car-price-search["']:\s*(patch|minor|major)/.test(doc)),
-    "expected a changeset entry that releases used-car-price-search",
-  );
-});
-
 test("package-lock captures the toss-securities workspace metadata for npm ci", () => {
   const packageLock = readJson("package-lock.json");
 


### PR DESCRIPTION
## Summary
- `chore: version packages` 커밋 이후 CI/CD가 `npm run ci` 단계에서 실패
- 원인: `used-car-price-search`의 changeset 파일 존재를 검증하는 테스트가 있었는데, `changeset version`이 실행되면서 해당 파일이 소비(삭제)됨
- 이미 0.1.0으로 퍼블리시 완료되어 해당 가드 테스트는 불필요하므로 제거
- release-npm.yml에 `workflow_dispatch` 추가하여 수동 릴리스 재트리거 가능하도록 변경
- CLAUDE.md, AGENTS.md에 changeset 파일 존재 assert 금지 규칙 추가

## Test plan
- [x] `npm run ci` 로컬 통과 확인
- [ ] CI 워크플로우 그린 확인
- [ ] 머지 후 `gh workflow run release-npm.yml`로 릴리스 재트리거

🤖 Generated with [Claude Code](https://claude.com/claude-code)