### PR TITLE
Add workflow_dispatch and changeset test anti-pattern docs

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -1,6 +1,7 @@
 name: Release npm packages
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,10 @@ These rules are repo-specific and apply to everything under this directory.
 - For release or packaging changes, run `npm run ci`.
 - Keep release docs, workflow files, and package metadata aligned in the same change.
 
+## Testing anti-patterns
+
+- **Never write tests that assert `.changeset/*.md` files exist.** Changesets are consumed (deleted) by `changeset version` during the release flow. Any test guarding changeset file presence will break CI on the version-bump commit and block the release pipeline.
+
 ## Development skill install rules
 
 - When testing or developing skills from this repository, install or sync the current skill directories into the user's home-directory global skill locations first.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# k-skill
+
+## Testing anti-patterns
+
+- **Never write tests that assert `.changeset/*.md` files exist.** Changesets are consumed (deleted) by `changeset version` during the release flow. Any test guarding changeset file presence will break CI on the version-bump commit and block the release pipeline.


### PR DESCRIPTION
## Summary
- release-npm.yml에 `workflow_dispatch` 트리거 추가 → 수동 릴리스 재트리거 가능
- CLAUDE.md, AGENTS.md에 `.changeset/*.md` 파일 존재 assert 금지 규칙 추가
- 이전 PR #50이 squash merge되면서 누락된 변경사항

## Test plan
- [ ] CI 그린 확인
- [ ] 머지 후 `gh workflow run release-npm.yml -r main`으로 릴리스 재트리거

🤖 Generated with [Claude Code](https://claude.com/claude-code)