### PR TITLE
Feature/#89

### DIFF
--- a/scripts/skill-docs.test.js
+++ b/scripts/skill-docs.test.js
@@ -1401,19 +1401,6 @@ test("pack:dry-run includes the toss-securities workspace", () => {
   assert.match(packageJson.scripts["pack:dry-run"], /workspace used-car-price-search/);
 });
 
-test("used-car-price-search ships with a changeset for release automation", () => {
-  const changesetDir = path.join(repoRoot, ".changeset");
-  const changesetFiles = fs
-    .readdirSync(changesetDir)
-    .filter((name) => name.endsWith(".md"))
-    .map((name) => read(path.join(".changeset", name)));
-
-  assert.ok(
-    changesetFiles.some((doc) => /["']used-car-price-search["']:\s*(patch|minor|major)/.test(doc)),
-    "expected a changeset entry that releases used-car-price-search",
-  );
-});
-
 test("package-lock captures the toss-securities workspace metadata for npm ci", () => {
   const packageLock = readJson("package-lock.json");
 


### PR DESCRIPTION
## Summary
- main hotfix #89 의 dev 백포트
- 동일한 anti-pattern이 dev `scripts/skill-docs.test.js` 에도 존재 → 다음 릴리즈 플로우에서 또 터질 것이므로 선제 제거
- CLAUDE.md 에 명시된 `.changeset/*.md` 존재 assert 금지 규칙 위반

## Test plan
- [x] `node --test scripts/skill-docs.test.js` 로컬 통과 (83/83)
- [x] `npm run ci`
