### PR TITLE
Fix extractDataGoItems to handle current data.go.kr JSON shapes

### DIFF
--- a/packages/k-skill-proxy/src/mfds.js
+++ b/packages/k-skill-proxy/src/mfds.js
@@ -147,13 +147,44 @@ async function requestJson(url, { params, fetchImpl = global.fetch } = {}) {
 }
 
 function extractDataGoItems(payload) {
-  const raw = payload?.body?.items?.item;
-  if (Array.isArray(raw)) {
-    return raw.filter((item) => item && typeof item === "object");
+  const items = payload?.body?.items;
+  if (!items) {
+    return [];
   }
-  if (raw && typeof raw === "object") {
-    return [raw];
+
+  // Shape A (legacy XML→JSON autoconvert): body.items = { item: [...] | {...} }
+  if (!Array.isArray(items) && typeof items === "object") {
+    const inner = items.item;
+    if (Array.isArray(inner)) {
+      return inner.filter((entry) => entry && typeof entry === "object");
+    }
+    if (inner && typeof inner === "object") {
+      return [inner];
+    }
+    return [];
   }
+
+  // Shape B (native JSON): body.items = [...] flat array of entries.
+  // Shape C (wrapped JSON): body.items = [{ item: {...} }, ...] where each entry has a single `item` key.
+  if (Array.isArray(items)) {
+    return items
+      .map((entry) => {
+        if (!entry || typeof entry !== "object") {
+          return null;
+        }
+        if (
+          entry.item &&
+          typeof entry.item === "object" &&
+          !Array.isArray(entry.item) &&
+          Object.keys(entry).length === 1
+        ) {
+          return entry.item;
+        }
+        return entry;
+      })
+      .filter((entry) => entry && typeof entry === "object");
+  }
+
   return [];
 }
 

--- a/packages/k-skill-proxy/test/server.test.js
+++ b/packages/k-skill-proxy/test/server.test.js
@@ -2292,16 +2292,14 @@ test("mfds drug-safety lookup endpoint proxies official drug surfaces and caches
       return new Response(
         JSON.stringify({
           body: {
-            items: {
-              item: [
-                {
-                  itemName: "타이레놀정160밀리그램",
-                  entpName: "한국얀센",
-                  efcyQesitm: "감기로 인한 발열 및 동통에 사용합니다.",
-                  intrcQesitm: "다른 해열진통제와 함께 복용하지 마십시오."
-                }
-              ]
-            }
+            items: [
+              {
+                itemName: "타이레놀정160밀리그램",
+                entpName: "한국얀센",
+                efcyQesitm: "감기로 인한 발열 및 동통에 사용합니다.",
+                intrcQesitm: "다른 해열진통제와 함께 복용하지 마십시오."
+              }
+            ]
           }
         }),
         {
@@ -2315,16 +2313,14 @@ test("mfds drug-safety lookup endpoint proxies official drug surfaces and caches
       return new Response(
         JSON.stringify({
           body: {
-            items: {
-              item: [
-                {
-                  PRDLST_NM: "판콜에스내복액",
-                  BSSH_NM: "동화약품",
-                  EFCY_QESITM: "감기 증상 완화",
-                  INTRC_QESITM: "다른 감기약과 병용 주의"
-                }
-              ]
-            }
+            items: [
+              {
+                PRDLST_NM: "판콜에스내복액",
+                BSSH_NM: "동화약품",
+                EFCY_QESITM: "감기 증상 완화",
+                INTRC_QESITM: "다른 감기약과 병용 주의"
+              }
+            ]
           }
         }),
         {
@@ -2362,6 +2358,78 @@ test("mfds drug-safety lookup endpoint proxies official drug surfaces and caches
   assert.equal(first.json().items[0].source, "drug_easy_info");
   assert.equal(first.json().items[1].source, "safe_standby_medicine");
   assert.ok(fetchCalls.every((entry) => entry.includes("test-key")));
+});
+
+test("mfds drug-safety lookup endpoint still parses legacy body.items.item shape", async (t) => {
+  const originalFetch = global.fetch;
+  global.fetch = async (url) => {
+    const text = String(url);
+    if (text.includes("DrbEasyDrugInfoService/getDrbEasyDrugList")) {
+      return new Response(
+        JSON.stringify({
+          body: {
+            items: {
+              item: [
+                {
+                  itemName: "레거시타이레놀",
+                  entpName: "레거시얀센"
+                }
+              ]
+            }
+          }
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json;charset=UTF-8" }
+        }
+      );
+    }
+
+    if (text.includes("SafeStadDrugService/getSafeStadDrugInq")) {
+      return new Response(
+        JSON.stringify({
+          body: {
+            items: {
+              item: {
+                PRDLST_NM: "레거시판콜",
+                BSSH_NM: "레거시동화"
+              }
+            }
+          }
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json;charset=UTF-8" }
+        }
+      );
+    }
+
+    throw new Error(`unexpected URL: ${url}`);
+  };
+
+  const app = buildServer({
+    env: {
+      DATA_GO_KR_API_KEY: "legacy-key"
+    }
+  });
+
+  t.after(async () => {
+    global.fetch = originalFetch;
+    await app.close();
+  });
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/v1/mfds/drug-safety/lookup?itemName=%ED%83%80%EC%9D%B4%EB%A0%88%EB%86%80&limit=5"
+  });
+
+  assert.equal(response.statusCode, 200);
+  const items = response.json().items;
+  assert.equal(items.length, 2);
+  assert.equal(items[0].source, "drug_easy_info");
+  assert.equal(items[0].item_name, "레거시타이레놀");
+  assert.equal(items[1].source, "safe_standby_medicine");
+  assert.equal(items[1].item_name, "레거시판콜");
 });
 
 test("mfds food-safety search endpoint requires query", async (t) => {
@@ -2444,16 +2512,16 @@ test("mfds food-safety search endpoint uses live recall key when configured", as
       return new Response(
         JSON.stringify({
           body: {
-            items: {
-              item: [
-                {
+            items: [
+              {
+                item: {
                   PRDUCT: "예시 유부초밥",
                   ENTRPS: "예시푸드",
                   IMPROPT_ITM: "황색포도상구균",
                   INSPCT_RESULT: "기준 부적합"
                 }
-              ]
-            }
+              }
+            ]
           }
         }),
         {


### PR DESCRIPTION
## Summary

While investigating issue #148 (식품안전체크 스킬 empty results), I found that `/v1/mfds/drug-safety/lookup` was **also silently broken** — returning `items: []` with no warning for valid queries like 타이레놀 / 게보린.

Root cause: MFDS data.go.kr JSON endpoints have moved off the legacy XML→JSON autoconvert shape (`body.items.item`) and now return either a flat array or a `{item: {...}}`-wrapped array. Our `extractDataGoItems` still expected the legacy shape only, so every request silently parsed as zero items.

## What this PR fixes

Verified against real upstream (2026-04-20, `DATA_GO_KR_API_KEY` set on proxy):

| Endpoint | `body.items` shape today | Old parser | New parser |
|---|---|---|---|
| `DrbEasyDrugInfoService/getDrbEasyDrugList` | `[{entpName, itemName, ...}]` flat | `[]` | ✅ data |
| `SafeStadDrugService/getSafeStadDrugInq` | `[{PRDLST_NM, BSSH_NM, ...}]` flat | `[]` | ✅ data |
| `PrsecImproptFoodInfoService03/getPrsecImproptFoodList01` | `[{item: {PRDUCT, ENTRPS, ...}}, ...]` wrapped | `[]` | ✅ data |
| (legacy) `{items: {item: [...]}}` | `[...]` | ✅ | ✅ (backward compat) |

### End-to-end verification against real `data.go.kr`

- `drug-safety/lookup?itemName=타이레놀` → before: `items: []`; after: 3 real 타이레놀 products
- `food-safety/search?query=청경채` → after: improperFood 청경채(강북공잔10-15-05) entry returned

### Test changes

- Updated `drug-safety` and `food-safety/search` mock fixtures in `test/server.test.js` to mirror the real upstream shapes (flat array + wrapped array), so tests fail if this regression reappears.
- Added a backward-compat test that feeds the legacy `body.items.item` shape and asserts we still parse it.
- 115 tests pass (previously 114).

## What this PR does NOT fix

Issue #148's primary user-facing warning —
`FoodSafetyKorea response was not valid JSON. Check FOODSAFETYKOREA_API_KEY on the proxy server.` — is an **operational key issue**, not a code bug. Direct upstream call with our current key returns `인증키가 유효하지 않습니다` HTML alert from `openapi.foodsafetykorea.go.kr`, meaning the key is expired/revoked. That needs:

1. Re-issue `FOODSAFETYKOREA_API_KEY` at https://www.foodsafetykorea.go.kr/
2. Update `~/.config/k-skill/secrets.env` on the proxy host
3. `pm2 restart k-skill-proxy` (run-k-skill-proxy.sh re-sources secrets on start)

I will leave a comment on #148 with this breakdown.

## Verification

- `npm test --workspace=k-skill-proxy` — 115/115 pass
- `npm test --workspaces --if-present` — all workspace tests pass
- `npm run ci` — pass
- Live upstream test with real proxy bound to port 4021: drug-safety returns real data, improperFood parsing correct
- `k-skill-proxy` is `"private": true`, so no changeset required

## Files changed

- `packages/k-skill-proxy/src/mfds.js` — widen `extractDataGoItems` to cover three shapes
- `packages/k-skill-proxy/test/server.test.js` — refresh mocks to match real upstream + add legacy backward-compat test