### PR TITLE
feat(ktx-booking): add --train-type flag for ITX/무궁화 routes

### DIFF
--- a/ktx-booking/SKILL.md
+++ b/ktx-booking/SKILL.md
@@ -82,6 +82,16 @@ python3 -m pip install korail2 pycryptodome
 python3 scripts/ktx_booking.py search 서울 부산 20260328 090000 --limit 5
 ```
 
+기본 `--train-type` 은 `ktx` 다. ITX-청춘(예: 남춘천↔용산)·ITX-새마을·무궁화호처럼 KTX 외 노선을 잡으려면 `--train-type` 으로 지정한다.
+
+```bash
+python3 scripts/ktx_booking.py search 남춘천 용산 20260503 150000 --train-type itx-cheongchun
+```
+
+선택지: `ktx`, `itx-saemaeul`, `mugunghwa`, `nuriro`, `tonggeun`, `itx-cheongchun`, `airport`, `all`.
+
+예약 단계(`reserve`)에서도 같은 `--train-type` 값을 그대로 넘겨야 stable `train_id` 매칭이 깨지지 않는다.
+
 좌석이 없는 열차도 후보에 포함하려면 `--include-no-seats`, 예약 대기 가능한 열차도 같이 보고 싶으면 `--include-waiting-list` 를 붙인다.
 
 ### 3. Present the shortlist
@@ -101,6 +111,12 @@ python3 scripts/ktx_booking.py search 서울 부산 20260328 090000 --limit 5
 
 ```bash
 python3 scripts/ktx_booking.py reserve 서울 부산 20260328 090000 --train-id <train_id> --seat-option general-first
+```
+
+ITX 등 KTX 외 노선을 search 단계에서 골랐다면 reserve 에도 똑같이 `--train-type` 을 넘긴다.
+
+```bash
+python3 scripts/ktx_booking.py reserve 남춘천 용산 20260503 150000 --train-id <train_id> --train-type itx-cheongchun --seat-option general-first
 ```
 
 응답에는 예약번호, 운임, 구입기한이 포함된다. **결제는 자동화하지 않는다.**

--- a/scripts/ktx_booking.py
+++ b/scripts/ktx_booking.py
@@ -83,8 +83,19 @@ except ModuleNotFoundError as exc:
         SPECIAL_ONLY = "SPECIAL_ONLY"
 
     class TrainType:
-        ALL = "ALL"
-        KTX = "KTX"
+        # Fallback constants used only when korail2 is missing so module
+        # import succeeds and ensure_runtime_dependencies() can surface
+        # the install message. Values mirror upstream korail2.TrainType.
+        KTX = "100"
+        KTX_SANCHEON = "100"
+        ITX_SAEMAEUL = "101"
+        SAEMAEUL = "101"
+        MUGUNGHWA = "102"
+        NURIRO = "102"
+        TONGGUEN = "103"
+        ITX_CHEONGCHUN = "104"
+        AIRPORT = "105"
+        ALL = "109"
 
     class Korail:
         def __init__(self, *args, **kwargs):

--- a/scripts/ktx_booking.py
+++ b/scripts/ktx_booking.py
@@ -113,6 +113,16 @@ RESERVE_OPTION_MAP = {
     "special-first": ReserveOption.SPECIAL_FIRST,
     "special-only": ReserveOption.SPECIAL_ONLY,
 }
+TRAIN_TYPE_MAP = {
+    "ktx": TrainType.KTX,                       # 100 — KTX/KTX-산천
+    "itx-saemaeul": TrainType.ITX_SAEMAEUL,     # 101 — ITX-새마을
+    "mugunghwa": TrainType.MUGUNGHWA,           # 102 — 무궁화호
+    "nuriro": TrainType.NURIRO,                 # 102 — 누리로
+    "tonggeun": TrainType.TONGGUEN,             # 103 — 통근열차
+    "itx-cheongchun": TrainType.ITX_CHEONGCHUN, # 104 — ITX-청춘
+    "airport": TrainType.AIRPORT,               # 105 — 공항직통
+    "all": TrainType.ALL,                       # 109 — 전체
+}
 TRAIN_ID_PREFIX = "ktx:v1:"
 TRAIN_ID_INVALID_MESSAGE = "train_id is invalid; rerun search and copy a fresh train_id"
 TRAIN_ID_STALE_MESSAGE = "train_id no longer matches any current search result; rerun search and choose a fresh train_id"
@@ -643,7 +653,7 @@ def command_search(args: argparse.Namespace) -> None:
         args.arr,
         args.date,
         args.time,
-        train_type=TrainType.KTX,
+        train_type=TRAIN_TYPE_MAP[args.train_type],
         passengers=passengers,
         include_no_seats=args.include_no_seats,
         include_waiting_list=args.include_waiting_list,
@@ -664,7 +674,7 @@ def command_reserve(args: argparse.Namespace) -> None:
         args.arr,
         args.date,
         args.time,
-        train_type=TrainType.KTX,
+        train_type=TRAIN_TYPE_MAP[args.train_type],
         passengers=passengers,
         include_no_seats=args.include_no_seats,
         include_waiting_list=include_waiting_list,
@@ -715,9 +725,15 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Patched KTX/Korail booking helper for k-skill")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    search_parser = subparsers.add_parser("search", help="KTX 열차를 조회합니다")
+    search_parser = subparsers.add_parser("search", help="KTX/Korail 열차를 조회합니다")
     add_common_trip_args(search_parser)
     search_parser.add_argument("--limit", type=int, default=5, help="출력할 최대 열차 수")
+    search_parser.add_argument(
+        "--train-type",
+        choices=sorted(TRAIN_TYPE_MAP),
+        default="ktx",
+        help="조회할 열차 종류 (기본 ktx). ITX-청춘 노선은 itx-cheongchun, 무궁화는 mugunghwa, 전체는 all 사용",
+    )
     search_parser.add_argument("--include-no-seats", action="store_true", help="매진 열차도 포함")
     search_parser.add_argument("--include-waiting-list", action="store_true", help="예약 대기 가능 열차도 포함")
     search_parser.set_defaults(func=command_search)
@@ -726,6 +742,12 @@ def build_parser() -> argparse.ArgumentParser:
     add_common_trip_args(reserve_parser)
     reserve_parser.add_argument("--train-id", required=True, help="search 결과에서 복사한 stable train_id")
     reserve_parser.add_argument("--seat-option", choices=sorted(RESERVE_OPTION_MAP), default="general-first")
+    reserve_parser.add_argument(
+        "--train-type",
+        choices=sorted(TRAIN_TYPE_MAP),
+        default="ktx",
+        help="재조회할 열차 종류 — search 단계에서 사용한 값과 동일하게 지정 (기본 ktx)",
+    )
     reserve_parser.add_argument("--include-no-seats", action="store_true", help="검색 시 매진 열차도 포함")
     reserve_parser.add_argument("--include-waiting-list", action="store_true", help="검색 시 예약대기 열차도 포함")
     reserve_parser.add_argument(

--- a/scripts/test_ktx_booking.py
+++ b/scripts/test_ktx_booking.py
@@ -114,6 +114,7 @@ class KtxBookingTests(unittest.TestCase):
             seniors=0,
             train_id=train_id,
             seat_option="general-first",
+            train_type="ktx",
             include_no_seats=False,
             include_waiting_list=False,
             try_waiting=False,
@@ -140,6 +141,7 @@ class KtxBookingTests(unittest.TestCase):
         ])
 
         self.assertEqual(args.train_id, "ktx:v1:test")
+        self.assertEqual(args.train_type, "ktx")
 
     def test_command_reserve_targets_exact_train_id_even_if_order_changes(self):
         sold_out_first = FakeTrain(
@@ -172,6 +174,21 @@ class KtxBookingTests(unittest.TestCase):
                     ktx_booking.command_reserve(self.make_args(train_id))
 
         self.assertIn("train_id", str(exc.exception))
+
+
+    def test_command_reserve_replays_selected_train_type(self):
+        selected = FakeTrain(train_no="009", dep_time="090000", arr_time="113000", label="selected")
+        train_id = ktx_booking.normalize_train(selected, index=1)["train_id"]
+        client = FakeClient([selected])
+        args = self.make_args(train_id)
+        args.train_type = "itx-cheongchun"
+
+        with patch.object(ktx_booking, "build_client", return_value=client):
+            with redirect_stdout(io.StringIO()):
+                ktx_booking.command_reserve(args)
+
+        self.assertEqual(client.search_calls[-1]["train_type"], ktx_booking.TRAIN_TYPE_MAP["itx-cheongchun"])
+        self.assertIs(client.reserved_train, selected)
 
     def test_command_reserve_try_waiting_replays_search_with_waiting_list_enabled(self):
         waiting_only = FakeTrain(

--- a/scripts/test_ktx_booking.py
+++ b/scripts/test_ktx_booking.py
@@ -1,7 +1,12 @@
 import argparse
+import importlib
 import io
+import subprocess
+import sys
+import textwrap
 import unittest
 from contextlib import redirect_stdout
+from pathlib import Path
 from unittest.mock import patch
 
 import ktx_booking
@@ -215,6 +220,78 @@ class KtxBookingTests(unittest.TestCase):
         self.assertTrue(client.search_calls)
         self.assertTrue(client.search_calls[-1]["include_waiting_list"])
         self.assertIs(client.reserved_train, waiting_only)
+
+
+class FallbackImportTests(unittest.TestCase):
+    def test_module_imports_when_korail2_is_missing(self):
+        script_dir = Path(__file__).resolve().parent
+        helper = textwrap.dedent(
+            """
+            import importlib
+            import sys
+
+            sys.modules["korail2"] = None
+            sys.modules.pop("ktx_booking", None)
+            module = importlib.import_module("ktx_booking")
+
+            assert module._KORAIL_IMPORT_ERROR is not None, "expected fallback path"
+            assert module.TRAIN_TYPE_MAP["ktx"] == "100"
+            assert module.TRAIN_TYPE_MAP["itx-cheongchun"] == "104"
+            assert module.TRAIN_TYPE_MAP["itx-saemaeul"] == "101"
+            assert module.TRAIN_TYPE_MAP["mugunghwa"] == "102"
+            assert module.TRAIN_TYPE_MAP["nuriro"] == "102"
+            assert module.TRAIN_TYPE_MAP["tonggeun"] == "103"
+            assert module.TRAIN_TYPE_MAP["airport"] == "105"
+            assert module.TRAIN_TYPE_MAP["all"] == "109"
+            print("ok")
+            """
+        ).strip()
+        env = {
+            "PYTHONPATH": str(script_dir),
+            "PYTHONNOUSERSITE": "1",
+            "PATH": "",
+        }
+        result = subprocess.run(
+            [sys.executable, "-S", "-c", helper],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("ok", result.stdout)
+
+    def test_help_works_when_korail2_is_missing(self):
+        script_dir = Path(__file__).resolve().parent
+        helper = textwrap.dedent(
+            """
+            import importlib
+            import sys
+
+            sys.modules["korail2"] = None
+            sys.modules.pop("ktx_booking", None)
+            module = importlib.import_module("ktx_booking")
+            parser = module.build_parser()
+            help_text = parser.format_help()
+            assert "search" in help_text
+            assert "reserve" in help_text
+            print("ok")
+            """
+        ).strip()
+        env = {
+            "PYTHONPATH": str(script_dir),
+            "PYTHONNOUSERSITE": "1",
+            "PATH": "",
+        }
+        result = subprocess.run(
+            [sys.executable, "-S", "-c", helper],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("ok", result.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- `command_search` and `command_reserve` hardcoded `train_type=TrainType.KTX` (`\"100\"`), silently excluding ITX-청춘, ITX-새마을, 무궁화호, etc.
- Routes served only by non-KTX trains (e.g. 남춘천→용산 via ITX-청춘 2080) returned zero results with no error.
- This PR adds an explicit `--train-type` flag (default: `ktx`) so the skill keeps its KTX-first identity but lets users opt into other Korail train types when needed.

## Why this shape (not changing the default to ALL)

The previous attempt (#171) flipped the default to `TrainType.ALL`, but that conflicts with the skill's name (`ktx-booking`) and the \"When to use\" examples in SKILL.md, which are all KTX. So this PR keeps `ktx` as default for backward compatibility and exposes the broader set as an explicit choice instead.

## CLI choices

```
ktx | itx-saemaeul | mugunghwa | nuriro | tonggeun | itx-cheongchun | airport | all
```

## Usage

```bash
# Default — unchanged (KTX only)
python3 scripts/ktx_booking.py search 서울 부산 20260328 090000

# ITX-청춘 routes (e.g. 남춘천→용산)
python3 scripts/ktx_booking.py search 남춘천 용산 20260503 150000 --train-type itx-cheongchun

# Reserve uses the same flag so the stable train_id matches
python3 scripts/ktx_booking.py reserve 남춘천 용산 20260503 150000 \
  --train-id <id> --train-type itx-cheongchun --seat-option general-first
```

## Test plan

- [x] `python3 scripts/ktx_booking.py search --help` shows new flag with all 8 choices
- [x] `python3 scripts/ktx_booking.py reserve --help` shows new flag with all 8 choices
- [ ] `search 서울 부산 ... ` (no `--train-type`) still returns KTX trains as before
- [ ] `search 남춘천 용산 ... --train-type itx-cheongchun` returns ITX-청춘 trains

🤖 Generated with [Claude Code](https://claude.com/claude-code)