### PR TITLE
Feature/#52

### DIFF
--- a/packages/lck-analytics/src/parse.js
+++ b/packages/lck-analytics/src/parse.js
@@ -38,8 +38,7 @@ function normalizeDateInput(value) {
   }
 
   const [year, month, day] = [match[1], match[2], match[3]];
-  const candidate = new Date(`${year}-${month}-${day}T00:00:00+09:00`);
-  if (Number.isNaN(candidate.getTime())) {
+  if (!isValidCalendarDate(year, month, day)) {
     throw new Error("date must be a valid Date or YYYY-MM-DD string.");
   }
 
@@ -49,6 +48,40 @@ function normalizeDateInput(value) {
     day,
     isoDate: `${year}-${month}-${day}`,
   };
+}
+
+function isValidCalendarDate(year, month, day) {
+  const numericYear = Number(year);
+  const numericMonth = Number(month);
+  const numericDay = Number(day);
+
+  if (!Number.isInteger(numericYear) || !Number.isInteger(numericMonth) || !Number.isInteger(numericDay)) {
+    return false;
+  }
+
+  if (numericMonth < 1 || numericMonth > 12 || numericDay < 1) {
+    return false;
+  }
+
+  const daysInMonth = [
+    31,
+    isLeapYear(numericYear) ? 29 : 28,
+    31,
+    30,
+    31,
+    30,
+    31,
+    31,
+    30,
+    31,
+    30,
+    31,
+  ][numericMonth - 1];
+  return numericDay <= daysInMonth;
+}
+
+function isLeapYear(year) {
+  return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
 }
 
 function eventToKoreaDateTime(startTime) {

--- a/packages/lck-analytics/test/index.test.js
+++ b/packages/lck-analytics/test/index.test.js
@@ -13,6 +13,7 @@ const {
   parseOracleCsv,
 } = require("../src/index");
 const {
+  normalizeDateInput,
   normalizeScheduleResponse,
   normalizeStandingsResponse,
 } = require("../src/parse");
@@ -43,6 +44,22 @@ test("normalizeScheduleResponse filters requested LCK date and Korean team alias
   assert.equal(result.matches[0].team1.currentName, "Hanwha Life Esports");
   assert.equal(result.matches[0].team2.currentName, "T1");
   assert.deepEqual(result.matches[0].score, { team1: 1, team2: 0 });
+});
+
+test("date normalization rejects impossible calendar dates", () => {
+  assert.equal(normalizeDateInput("2024-02-29").isoDate, "2024-02-29");
+  assert.throws(
+    () => normalizeDateInput("2026-02-31"),
+    /date must be a valid Date or YYYY-MM-DD string\./,
+  );
+  assert.throws(
+    () => normalizeDateInput("2026-02-29"),
+    /date must be a valid Date or YYYY-MM-DD string\./,
+  );
+  assert.throws(
+    () => normalizeScheduleResponse(schedulePayload, { date: "2026-02-31" }),
+    /date must be a valid Date or YYYY-MM-DD string\./,
+  );
 });
 
 test("normalizeStandingsResponse keeps the LCK standings shape and alias resolution", () => {


### PR DESCRIPTION
<!-- dani:stage=implementation;job=0e48d52729814a8cb7cda387295c3d1b;issue=52 -->

## Summary
- follow up PR #55 review by making `lck-analytics` reject impossible calendar dates such as `2026-02-31`
- add regression coverage for valid leap day, invalid non-leap day, impossible month-day overflow, and schedule normalization rejection
- keep date validation before schedule filtering so invalid user input cannot become a misleading empty match result

## Verification
- `node --test packages/lck-analytics/test/index.test.js scripts/skill-docs.test.js`
- `npm run lint --workspace lck-analytics`
- `npm test --workspace lck-analytics`
- `npm run ci`
- rejection smoke: `getMatchResults('2026-02-31')`
- live smoke: `getLckSummary('2026-04-01', { team: '한화', includeStandings: true })`
- script smoke: `sync-oracle.js`, `build-match-report.js`, `analyze-live-game.js`
