### PR TITLE
Feature/#171

### DIFF
--- a/ktx-booking/SKILL.md
+++ b/ktx-booking/SKILL.md
@@ -101,7 +101,7 @@ python3 scripts/ktx_booking.py search 남춘천 용산 20260503 150000 --train-t
 - `index`
 - `train_id`
 - 출발/도착 시각
-- KTX 여부
+- 열차 종류 (`train_type`)
 - 일반실/특실 가능 여부
 - 예약 대기 가능 여부
 

--- a/scripts/test_ktx_booking.py
+++ b/scripts/test_ktx_booking.py
@@ -147,6 +147,17 @@ class KtxBookingTests(unittest.TestCase):
         self.assertEqual(args.train_id, "ktx:v1:test")
         self.assertEqual(args.train_type, "ktx")
 
+    def test_build_parser_defaults_search_train_type_to_ktx(self):
+        args = ktx_booking.build_parser().parse_args([
+            "search",
+            "서울",
+            "부산",
+            "20260328",
+            "090000",
+        ])
+
+        self.assertEqual(args.train_type, "ktx")
+
     def test_parser_train_type_choices_match_supported_train_types(self):
         parser = ktx_booking.build_parser()
         for train_type in sorted(ktx_booking.TRAIN_TYPE_MAP):

--- a/scripts/test_ktx_booking.py
+++ b/scripts/test_ktx_booking.py
@@ -1,5 +1,4 @@
 import argparse
-import importlib
 import io
 import subprocess
 import sys
@@ -147,6 +146,63 @@ class KtxBookingTests(unittest.TestCase):
 
         self.assertEqual(args.train_id, "ktx:v1:test")
         self.assertEqual(args.train_type, "ktx")
+
+    def test_parser_train_type_choices_match_supported_train_types(self):
+        parser = ktx_booking.build_parser()
+        for train_type in sorted(ktx_booking.TRAIN_TYPE_MAP):
+            search_args = parser.parse_args([
+                "search",
+                "서울",
+                "부산",
+                "20260328",
+                "090000",
+                "--train-type",
+                train_type,
+            ])
+            reserve_args = parser.parse_args([
+                "reserve",
+                "서울",
+                "부산",
+                "20260328",
+                "090000",
+                "--train-id",
+                "ktx:v1:test",
+                "--train-type",
+                train_type,
+            ])
+            self.assertEqual(search_args.train_type, train_type)
+            self.assertEqual(reserve_args.train_type, train_type)
+
+    def test_command_search_replays_selected_train_type(self):
+        selected = FakeTrain(
+            train_no="2080",
+            dep_time="155300",
+            arr_time="170000",
+            dep_name="남춘천",
+            arr_name="용산",
+            train_type_name="ITX-청춘",
+        )
+        client = FakeClient([selected])
+        args = argparse.Namespace(
+            dep="남춘천",
+            arr="용산",
+            date="20260503",
+            time="150000",
+            adults=1,
+            children=0,
+            toddlers=0,
+            seniors=0,
+            limit=5,
+            train_type="itx-cheongchun",
+            include_no_seats=False,
+            include_waiting_list=False,
+        )
+
+        with patch.object(ktx_booking, "build_client", return_value=client):
+            with redirect_stdout(io.StringIO()):
+                ktx_booking.command_search(args)
+
+        self.assertEqual(client.search_calls[-1]["train_type"], ktx_booking.TRAIN_TYPE_MAP["itx-cheongchun"])
 
     def test_command_reserve_targets_exact_train_id_even_if_order_changes(self):
         sold_out_first = FakeTrain(

--- a/scripts/test_ktx_booking.py
+++ b/scripts/test_ktx_booking.py
@@ -130,7 +130,10 @@ class KtxBookingTests(unittest.TestCase):
         normalized = ktx_booking.normalize_train(train, index=2)
 
         self.assertIn("train_id", normalized)
-        resolved = ktx_booking.find_train_by_id([train], normalized["train_id"])
+        train_id = normalized["train_id"]
+        if not isinstance(train_id, str):
+            self.fail("train_id should be emitted as a string")
+        resolved = ktx_booking.find_train_by_id([train], train_id)
         self.assertIs(resolved, train)
 
     def test_build_parser_requires_train_id_for_reserve(self):
@@ -213,7 +216,10 @@ class KtxBookingTests(unittest.TestCase):
             with redirect_stdout(io.StringIO()):
                 ktx_booking.command_search(args)
 
-        self.assertEqual(client.search_calls[-1]["train_type"], ktx_booking.TRAIN_TYPE_MAP["itx-cheongchun"])
+        self.assertEqual(
+            client.search_calls[-1]["train_type"],
+            ktx_booking.TRAIN_TYPE_MAP["itx-cheongchun"],
+        )
 
     def test_command_reserve_targets_exact_train_id_even_if_order_changes(self):
         sold_out_first = FakeTrain(
@@ -246,7 +252,6 @@ class KtxBookingTests(unittest.TestCase):
                     ktx_booking.command_reserve(self.make_args(train_id))
 
         self.assertIn("train_id", str(exc.exception))
-
 
     def test_command_reserve_replays_selected_train_type(self):
         selected = FakeTrain(train_no="009", dep_time="090000", arr_time="113000", label="selected")


### PR DESCRIPTION
## Summary

- Adds follow-up regression coverage for Issue #171 / PR #172 so `search` and `reserve` keep accepting every supported `--train-type` choice from `TRAIN_TYPE_MAP`.
- Locks the original non-KTX route fix at command level by asserting `command_search` passes `itx-cheongchun` through to `search_train` instead of silently falling back to KTX.
- Adds an explicit parser regression that `search` still defaults to `ktx` when `--train-type` is omitted.
- Removes stale test import noise and updates the ktx-booking skill shortlist wording from KTX-only boolean language to `train_type`.

## Verification

- [x] `python3 scripts/ktx_booking.py search --help`
- [x] `python3 scripts/ktx_booking.py reserve --help`
- [x] `PYTHONPATH=scripts python3 -m unittest scripts.test_ktx_booking`
- [x] `python3 -m py_compile scripts/ktx_booking.py scripts/test_ktx_booking.py`
- [x] `PYTHONNOUSERSITE=1 PYTHONPATH=scripts python3 -S -c 'import ktx_booking; print(ktx_booking._KORAIL_IMPORT_ERROR); print(ktx_booking.TRAIN_TYPE_MAP["itx-cheongchun"])'`
- [x] `PYTHONNOUSERSITE=1 PYTHONPATH=scripts python3 -m unittest discover -s scripts -p 'test_ktx_booking.py'`
- [x] `python3 -S scripts/ktx_booking.py search --help`
- [x] `python3 -S scripts/ktx_booking.py reserve --help`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`

Not tested: live Korail search/reserve requiring credentials and external service availability.

🤖 Generated with Codex
