### PR TITLE
fix: make setup permission check portable

### DIFF
--- a/scripts/check-setup.sh
+++ b/scripts/check-setup.sh
@@ -9,7 +9,11 @@ if [[ ! -f "$secrets_file" ]]; then
   echo "missing secrets file: $secrets_file"
   missing=1
 else
-  perms=$(stat -f '%Lp' "$secrets_file" 2>/dev/null || stat -c '%a' "$secrets_file" 2>/dev/null)
+  if stat --version >/dev/null 2>&1; then
+    perms=$(stat -c '%a' "$secrets_file")
+  else
+    perms=$(stat -f '%Lp' "$secrets_file")
+  fi
   if [[ "$perms" != "600" ]]; then
     echo "insecure permissions on $secrets_file: $perms (expected 600)"
     missing=1


### PR DESCRIPTION
## Summary
- make `scripts/check-setup.sh` choose GNU vs BSD `stat` explicitly
- avoid misreading `~/.config/k-skill/secrets.env` permissions as non-0600 on GNU/Linux

## Verification
- `bash scripts/check-setup.sh` → `k-skill setup looks usable`
- `git show --check HEAD`
