### PR TITLE
feat: add SH notice search skill

### DIFF
--- a/packages/k-skill-proxy/package.json
+++ b/packages/k-skill-proxy/package.json
@@ -9,7 +9,7 @@
     "node": ">=18"
   },
   "scripts": {
-    "lint": "node --check src/airkorea.js && node --check src/bluer.js && node --check src/hrfco.js && node --check src/krx-stock.js && node --check src/lh-notice.js && node --check src/mfds.js && node --check src/molit.js && node --check src/naver-news.js && node --check src/naver-shopping.js && node --check src/parking-lots.js && node --check src/region-lookup.js && node --check src/server.js && node --check test/airkorea.test.js && node --check test/hrfco.test.js && node --check test/lh-notice.test.js && node --check test/molit.test.js && node --check test/naver-news.test.js && node --check test/naver-shopping.test.js && node --check test/region-lookup.test.js && node --check test/server.test.js",
+    "lint": "node --check src/airkorea.js && node --check src/bluer.js && node --check src/hrfco.js && node --check src/krx-stock.js && node --check src/lh-notice.js && node --check src/sh-notice.js && node --check src/mfds.js && node --check src/molit.js && node --check src/naver-news.js && node --check src/naver-shopping.js && node --check src/parking-lots.js && node --check src/region-lookup.js && node --check src/server.js && node --check test/airkorea.test.js && node --check test/hrfco.test.js && node --check test/lh-notice.test.js && node --check test/sh-notice.test.js && node --check test/molit.test.js && node --check test/naver-news.test.js && node --check test/naver-shopping.test.js && node --check test/region-lookup.test.js && node --check test/server.test.js",
     "test": "node --test"
   },
   "dependencies": {

--- a/packages/k-skill-proxy/src/server.js
+++ b/packages/k-skill-proxy/src/server.js
@@ -19,6 +19,12 @@ const {
   normalizeLhNoticeDetailQuery,
   normalizeLhNoticeSearchQuery
 } = require("./lh-notice");
+const {
+  fetchShNoticeDetail,
+  fetchShNoticeList,
+  normalizeShNoticeDetailQuery,
+  normalizeShNoticeSearchQuery
+} = require("./sh-notice");
 const { fetchTransactions, VALID_ASSET_TYPES, VALID_DEAL_TYPES } = require("./molit");
 const { fetchNaverNewsSearch, normalizeNaverNewsSearchQuery } = require("./naver-news");
 const { fetchNaverShoppingSearch, normalizeNaverShoppingSearchQuery } = require("./naver-shopping");
@@ -2244,6 +2250,118 @@ function buildServer({ env = process.env, provider = null, now = () => new Date(
           hit: false,
           ttl_ms: config.cacheTtlMs
         },
+        requested_at: new Date().toISOString()
+      }
+    };
+
+    cache.set(cacheKey, payload, config.cacheTtlMs);
+    return payload;
+  });
+
+  app.get("/v1/sh-notice/search", async (request, reply) => {
+    let normalized;
+
+    try {
+      normalized = normalizeShNoticeSearchQuery(request.query || {});
+    } catch (error) {
+      reply.code(400);
+      return {
+        error: "bad_request",
+        message: error.message
+      };
+    }
+
+    const cacheKey = makeCacheKey({
+      route: "sh-notice-search",
+      ...normalized
+    });
+    const cached = cache.get(cacheKey);
+    if (cached) {
+      return {
+        ...cached,
+        proxy: {
+          ...cached.proxy,
+          cache: { hit: true, ttl_ms: config.cacheTtlMs }
+        }
+      };
+    }
+
+    let body;
+    try {
+      body = await fetchShNoticeList({ filters: normalized });
+    } catch (error) {
+      reply.code(error.statusCode && error.statusCode >= 400 ? error.statusCode : 502);
+      return {
+        error: error.code || "proxy_error",
+        message: error.message,
+        proxy: {
+          name: config.proxyName,
+          cache: { hit: false, ttl_ms: config.cacheTtlMs }
+        }
+      };
+    }
+
+    const payload = {
+      ...body,
+      proxy: {
+        name: config.proxyName,
+        cache: { hit: false, ttl_ms: config.cacheTtlMs },
+        requested_at: new Date().toISOString()
+      }
+    };
+
+    cache.set(cacheKey, payload, config.cacheTtlMs);
+    return payload;
+  });
+
+  app.get("/v1/sh-notice/detail", async (request, reply) => {
+    let normalized;
+
+    try {
+      normalized = normalizeShNoticeDetailQuery(request.query || {});
+    } catch (error) {
+      reply.code(400);
+      return {
+        error: "bad_request",
+        message: error.message
+      };
+    }
+
+    const cacheKey = makeCacheKey({
+      route: "sh-notice-detail",
+      ...normalized
+    });
+    const cached = cache.get(cacheKey);
+    if (cached) {
+      return {
+        ...cached,
+        proxy: {
+          ...cached.proxy,
+          cache: { hit: true, ttl_ms: config.cacheTtlMs }
+        }
+      };
+    }
+
+    let body;
+    try {
+      body = await fetchShNoticeDetail({ filters: normalized });
+    } catch (error) {
+      reply.code(error.statusCode && error.statusCode >= 400 ? error.statusCode : 502);
+      return {
+        error: error.code || "proxy_error",
+        message: error.message,
+        proxy: {
+          name: config.proxyName,
+          cache: { hit: false, ttl_ms: config.cacheTtlMs }
+        }
+      };
+    }
+
+    const payload = {
+      ...body,
+      proxy: {
+        name: config.proxyName,
+        cache: { hit: false, ttl_ms: config.cacheTtlMs },
         requested_at: new Date().toISOString()
       }
     };

--- a/packages/k-skill-proxy/src/sh-notice.js
+++ b/packages/k-skill-proxy/src/sh-notice.js
@@ -1,0 +1,248 @@
+// SH 공고/공지 (Seoul Housing & Communities Corporation) scraper.
+// SH does not expose the same data.go.kr envelope as LH for this board, so this
+// wrapper reads the official i-sh.co.kr board HTML and normalizes list/detail rows.
+
+const SH_BASE_URL = "https://www.i-sh.co.kr";
+const SH_NOTICE_PATH = "/app/lay2/program/S48T1581C563/www/brd/m_247";
+const SH_LIST_URL = `${SH_BASE_URL}${SH_NOTICE_PATH}/list.do`;
+const SH_VIEW_URL = `${SH_BASE_URL}${SH_NOTICE_PATH}/view.do`;
+const DEFAULT_MULTI_ITM_SEQ = "2";
+
+function trimOrNull(value) {
+  if (value === undefined || value === null) return null;
+  const trimmed = String(value).replace(/\s+/g, " ").trim();
+  return trimmed || null;
+}
+
+function decodeHtml(value) {
+  if (value === undefined || value === null) return "";
+  return String(value)
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&#x27;/g, "'")
+    .replace(/&nbsp;/g, " ");
+}
+
+function stripTags(html) {
+  return decodeHtml(String(html || "").replace(/<script[\s\S]*?<\/script>/gi, " ").replace(/<style[\s\S]*?<\/style>/gi, " ").replace(/<[^>]+>/g, " "));
+}
+
+function absolutizeUrl(url) {
+  const clean = decodeHtml(url || "").trim();
+  if (!clean) return null;
+  return new URL(clean, SH_BASE_URL).toString();
+}
+
+function parseBoundedInt(value, { defaultValue, min, max, label }) {
+  if (value === undefined || value === null || String(value).trim() === "") return defaultValue;
+  const text = String(value).trim();
+  if (!/^\d+$/.test(text)) throw new Error(`Provide valid ${label}.`);
+  const parsed = Number.parseInt(text, 10);
+  if (parsed < min) return min;
+  if (parsed > max) return max;
+  return parsed;
+}
+
+function normalizeShNoticeSearchQuery(query) {
+  const srchTp = trimOrNull(query.srchTp ?? query.searchType ?? query.type);
+  if (srchTp && !["title", "content", "1", "2", "제목", "내용"].includes(srchTp)) {
+    throw new Error("srchTp must be title/content or 제목/내용.");
+  }
+  const mappedSrchTp = srchTp === "title" || srchTp === "제목" ? "1" : srchTp === "content" || srchTp === "내용" ? "2" : srchTp;
+  return {
+    page: parseBoundedInt(query.page ?? query.pageNo, { defaultValue: 1, min: 1, max: 1000, label: "page" }),
+    pageSize: parseBoundedInt(query.pageSize ?? query.limit, { defaultValue: 10, min: 1, max: 100, label: "pageSize" }),
+    srchWord: trimOrNull(query.srchWord ?? query.q ?? query.query ?? query.keyword),
+    srchTp: mappedSrchTp || null,
+    multiItmSeq: trimOrNull(query.multiItmSeq ?? query.multi_itm_seq) || DEFAULT_MULTI_ITM_SEQ
+  };
+}
+
+function normalizeShNoticeDetailQuery(query) {
+  const seq = trimOrNull(query.seq ?? query.noticeSeq ?? query.id);
+  if (!seq) throw new Error("Provide seq.");
+  if (!/^\d{1,20}$/.test(seq)) throw new Error("seq must be digits only.");
+  return {
+    seq,
+    multiItmSeq: trimOrNull(query.multiItmSeq ?? query.multi_itm_seq) || DEFAULT_MULTI_ITM_SEQ
+  };
+}
+
+function buildSearchUrl(filters) {
+  const url = new URL(SH_LIST_URL);
+  url.searchParams.set("multi_itm_seq", filters.multiItmSeq || DEFAULT_MULTI_ITM_SEQ);
+  if (filters.page) url.searchParams.set("page", String(filters.page));
+  if (filters.srchWord) url.searchParams.set("srchWord", filters.srchWord);
+  if (filters.srchTp) url.searchParams.set("srchTp", filters.srchTp);
+  return url;
+}
+
+function buildDetailUrl(filters) {
+  const url = new URL(SH_VIEW_URL);
+  url.searchParams.set("multi_itm_seq", filters.multiItmSeq || DEFAULT_MULTI_ITM_SEQ);
+  url.searchParams.set("seq", filters.seq);
+  return url;
+}
+
+function extractTotalCount(html) {
+  const text = stripTags(html);
+  const match = text.match(/총\s*([0-9,]+)\s*건/);
+  return match ? Number.parseInt(match[1].replace(/,/g, ""), 10) : null;
+}
+
+function parseListRows(html, filters = {}) {
+  const tbodyMatch = String(html || "").match(/<tbody[^>]*>([\s\S]*?)<\/tbody>/i);
+  const tbody = tbodyMatch ? tbodyMatch[1] : String(html || "");
+  const rows = [];
+  const rowRegex = /<tr[^>]*>([\s\S]*?)<\/tr>/gi;
+  let rowMatch;
+  while ((rowMatch = rowRegex.exec(tbody))) {
+    const row = rowMatch[1];
+    const seqMatch = row.match(/getDetailView\(['"]?(\d+)['"]?\)/i);
+    if (!seqMatch) continue;
+    const cells = [...row.matchAll(/<td[^>]*>([\s\S]*?)<\/td>/gi)].map((m) => m[1]);
+    if (cells.length < 5) continue;
+    const titleAnchor = cells[1].match(/<a[^>]*>([\s\S]*?)<\/a>/i);
+    const rawTitle = (titleAnchor ? titleAnchor[1] : cells[1]).replace(/<span[^>]*class=["'][^"']*icoNew[^"']*["'][^>]*>[\s\S]*?<\/span>/gi, " ");
+    const title = trimOrNull(stripTags(rawTitle).replace(/^NEW\s*/i, ""));
+    const seq = seqMatch[1];
+    rows.push({
+      seq,
+      number: trimOrNull(stripTags(cells[0])),
+      title,
+      department: trimOrNull(stripTags(cells[2])),
+      registered_date: trimOrNull(stripTags(cells[3])),
+      views: (() => {
+        const v = trimOrNull(stripTags(cells[4]));
+        return v && /^[0-9,]+$/.test(v) ? Number.parseInt(v.replace(/,/g, ""), 10) : null;
+      })(),
+      is_new: /icoNew/i.test(cells[1]),
+      detail_url: buildDetailUrl({ seq, multiItmSeq: filters.multiItmSeq || DEFAULT_MULTI_ITM_SEQ }).toString()
+    });
+  }
+  return rows;
+}
+
+function parseAttachments(html, seq) {
+  const attachments = [];
+  const rowRegex = /<tr[^>]*>[\s\S]*?<th[^>]*>\s*첨부\s*<\/th>[\s\S]*?<td[^>]*>([\s\S]*?)<\/td>[\s\S]*?<\/tr>/gi;
+  let match;
+  while ((match = rowRegex.exec(String(html || "")))) {
+    const cell = match[1];
+    const fileAnchor = cell.match(/<a[^>]*class=["'][^"']*btnAttach[^"']*["'][^>]*>([\s\S]*?)<\/a>/i);
+    const filename = trimOrNull(stripTags(fileAnchor ? fileAnchor[1] : ""));
+    if (!filename) continue;
+    const previewMatch = cell.match(/<a[^>]*href=["']([^"']*htmlConverter\.do[^"']*)["'][^>]*>/i);
+    const previewUrl = previewMatch ? absolutizeUrl(previewMatch[1]) : null;
+    const fileSeqMatch = previewUrl ? previewUrl.match(/[?&]file_seq=(\d+)/) : null;
+    attachments.push({
+      filename,
+      file_seq: fileSeqMatch ? fileSeqMatch[1] : null,
+      preview_url: previewUrl,
+      download_hint: seq && fileSeqMatch ? `${SH_BASE_URL}/app/com/file/fileDown.do?brd_id=GS0401&seq=${seq}&file_seq=${fileSeqMatch[1]}` : null
+    });
+  }
+  return attachments;
+}
+
+function parseDetail(html, filters) {
+  const titleMatch = String(html || "").match(/<caption>([\s\S]*?)<\/caption>/i) || String(html || "").match(/<thead>[\s\S]*?<th[^>]*colspan=["']2["'][^>]*>([\s\S]*?)<\/th>/i);
+  const title = trimOrNull(stripTags(titleMatch ? titleMatch[1] : ""));
+  const registeredMatch = String(html || "").match(/<strong>\s*등록일\s*:\s*<\/strong>\s*([0-9]{4}[-.][0-9]{2}[-.][0-9]{2})/i);
+  const viewsMatch = String(html || "").match(/<strong>\s*조회수\s*:\s*<\/strong>\s*([0-9,]+)/i);
+  const contentMatch = String(html || "").match(/<td[^>]*class=["']cont["'][^>]*>([\s\S]*?)<\/td>/i);
+  const contentText = trimOrNull(stripTags(contentMatch ? contentMatch[1] : ""));
+  return {
+    seq: filters.seq,
+    title,
+    registered_date: registeredMatch ? registeredMatch[1].replace(/\./g, "-") : null,
+    views: viewsMatch ? Number.parseInt(viewsMatch[1].replace(/,/g, ""), 10) : null,
+    content_text: contentText,
+    attachments: parseAttachments(html, filters.seq),
+    detail_url: buildDetailUrl(filters).toString()
+  };
+}
+
+function buildListResponseBody(html, filters) {
+  const allItems = parseListRows(html, filters);
+  const items = allItems.slice(0, filters.pageSize);
+  return {
+    items,
+    summary: {
+      page: filters.page,
+      page_size: filters.pageSize,
+      returned_count: items.length,
+      total_count: extractTotalCount(html)
+    },
+    query: {
+      srch_word: filters.srchWord || null,
+      srch_tp: filters.srchTp || null,
+      multi_itm_seq: filters.multiItmSeq || DEFAULT_MULTI_ITM_SEQ
+    }
+  };
+}
+
+function buildDetailResponseBody(html, filters) {
+  return {
+    notice: parseDetail(html, filters),
+    query: {
+      seq: filters.seq,
+      multi_itm_seq: filters.multiItmSeq || DEFAULT_MULTI_ITM_SEQ
+    }
+  };
+}
+
+async function fetchText(url, { fetchImpl = global.fetch, timeoutMs = 20000 } = {}) {
+  let response;
+  try {
+    response = await fetchImpl(url.toString(), {
+      headers: { Accept: "text/html,application/xhtml+xml" },
+      signal: AbortSignal.timeout(timeoutMs)
+    });
+  } catch (err) {
+    const error = new Error(`SH upstream request failed: ${err.message}`);
+    error.statusCode = 502;
+    error.code = "upstream_fetch_failed";
+    throw error;
+  }
+  const text = await response.text();
+  if (!response.ok) {
+    const error = new Error(`SH upstream responded with HTTP ${response.status}: ${text.slice(0, 200)}`);
+    error.statusCode = 502;
+    error.code = "upstream_error";
+    throw error;
+  }
+  return text;
+}
+
+async function fetchShNoticeList({ filters, fetchImpl = global.fetch }) {
+  const html = await fetchText(buildSearchUrl(filters), { fetchImpl });
+  return buildListResponseBody(html, filters);
+}
+
+async function fetchShNoticeDetail({ filters, fetchImpl = global.fetch }) {
+  const html = await fetchText(buildDetailUrl(filters), { fetchImpl });
+  return buildDetailResponseBody(html, filters);
+}
+
+module.exports = {
+  SH_BASE_URL,
+  SH_NOTICE_PATH,
+  SH_LIST_URL,
+  SH_VIEW_URL,
+  DEFAULT_MULTI_ITM_SEQ,
+  normalizeShNoticeSearchQuery,
+  normalizeShNoticeDetailQuery,
+  buildSearchUrl,
+  buildDetailUrl,
+  parseListRows,
+  parseAttachments,
+  parseDetail,
+  buildListResponseBody,
+  buildDetailResponseBody,
+  fetchShNoticeList,
+  fetchShNoticeDetail
+};

--- a/packages/k-skill-proxy/test/sh-notice.test.js
+++ b/packages/k-skill-proxy/test/sh-notice.test.js
@@ -1,0 +1,101 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  buildDetailResponseBody,
+  buildListResponseBody,
+  buildSearchUrl,
+  normalizeShNoticeDetailQuery,
+  normalizeShNoticeSearchQuery,
+  parseAttachments,
+  parseDetail,
+  parseListRows
+} = require("../src/sh-notice");
+
+const LIST_HTML = `
+<p>총 <strong>1606</strong>건, 1/161페이지</p>
+<table><tbody>
+<tr>
+  <td>1606</td>
+  <td class="txtL"><a href="#" class="ellipsis icon" onclick="javascript:getDetailView('304022');return false;"><span class="icoNew">NEW</span> 전산작업에 따른 서비스(신한인증서) 이용 안내</a></td>
+  <td>시스템운영부</td>
+  <td class="num">2026-05-08</td>
+  <td class="num">97</td>
+</tr>
+<tr>
+  <td>1605</td>
+  <td class="txtL"><a href="#" class="ellipsis" onclick="javascript:getDetailView('303994');return false;">행복주택 예비당첨자 게시</a></td>
+  <td>공공주택공급부</td>
+  <td class="num">2026-05-07</td>
+  <td class="num">1,972</td>
+</tr>
+</tbody></table>`;
+
+const DETAIL_HTML = `
+<table>
+  <caption>행복주택 예비당첨자 게시</caption>
+  <tbody>
+    <tr><td><strong>등록일 :</strong> 2026-05-07 <strong>조회수 :</strong> 1,972</td></tr>
+    <tr><th scope="row">첨부</th><td>
+      <a href="#" class="btnAttach v1" onclick="existFile('0'); return false;">2022년 2차 행복주택 예비 17차 당첨자명단.pdf</a>
+      <a href="/app/com/util/htmlConverter.do?brd_id=GS0401&amp;seq=303994&amp;data_tp=A&amp;file_seq=1" class="btn btnWhite h32 icoView" target="_blank">미리보기</a>
+    </td></tr>
+    <tr><td colspan="2" class="cont"><p>2022년 2차 행복주택 예비17차 당첨자 발표</p><p>계약 안내를 확인하세요.</p></td></tr>
+  </tbody>
+</table>`;
+
+test("normalizeShNoticeSearchQuery maps aliases and bounds page size", () => {
+  const normalized = normalizeShNoticeSearchQuery({ q: "행복주택", searchType: "제목", page: "2", limit: "200" });
+  assert.equal(normalized.srchWord, "행복주택");
+  assert.equal(normalized.srchTp, "1");
+  assert.equal(normalized.page, 2);
+  assert.equal(normalized.pageSize, 100);
+});
+
+test("normalizeShNoticeDetailQuery requires numeric seq", () => {
+  assert.equal(normalizeShNoticeDetailQuery({ id: "303994" }).seq, "303994");
+  assert.throws(() => normalizeShNoticeDetailQuery({ seq: "abc" }), /digits only/);
+});
+
+test("buildSearchUrl targets official SH list page", () => {
+  const url = buildSearchUrl(normalizeShNoticeSearchQuery({ keyword: "원룸", srchTp: "content" }));
+  assert.equal(url.hostname, "www.i-sh.co.kr");
+  assert.equal(url.searchParams.get("srchTp"), "2");
+  assert.equal(url.searchParams.get("srchWord"), "원룸");
+});
+
+test("parseListRows extracts SH notice list", () => {
+  const rows = parseListRows(LIST_HTML, { multiItmSeq: "2" });
+  assert.equal(rows.length, 2);
+  assert.deepEqual(rows[0], {
+    seq: "304022",
+    number: "1606",
+    title: "전산작업에 따른 서비스(신한인증서) 이용 안내",
+    department: "시스템운영부",
+    registered_date: "2026-05-08",
+    views: 97,
+    is_new: true,
+    detail_url: "https://www.i-sh.co.kr/app/lay2/program/S48T1581C563/www/brd/m_247/view.do?multi_itm_seq=2&seq=304022"
+  });
+  assert.equal(rows[1].views, 1972);
+});
+
+test("buildListResponseBody limits returned items and includes total", () => {
+  const body = buildListResponseBody(LIST_HTML, { page: 1, pageSize: 1, multiItmSeq: "2" });
+  assert.equal(body.items.length, 1);
+  assert.equal(body.summary.total_count, 1606);
+  assert.equal(body.summary.returned_count, 1);
+});
+
+test("parseAttachments and parseDetail extract preview links and content", () => {
+  const attachments = parseAttachments(DETAIL_HTML, "303994");
+  assert.equal(attachments.length, 1);
+  assert.equal(attachments[0].file_seq, "1");
+  assert.equal(attachments[0].preview_url, "https://www.i-sh.co.kr/app/com/util/htmlConverter.do?brd_id=GS0401&seq=303994&data_tp=A&file_seq=1");
+
+  const detail = parseDetail(DETAIL_HTML, { seq: "303994", multiItmSeq: "2" });
+  assert.equal(detail.title, "행복주택 예비당첨자 게시");
+  assert.equal(detail.registered_date, "2026-05-07");
+  assert.equal(detail.views, 1972);
+  assert.match(detail.content_text, /계약 안내/);
+});
+

--- a/sh-notice-search/SKILL.md
+++ b/sh-notice-search/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: sh-notice-search
+description: Search official SH 서울주택도시개발공사 공고/공지 lists and details through k-skill-proxy. Use when a user asks about SH, 서울주택도시공사/서울주택도시개발공사, i-sh, 서울 행복주택/임대/공공원룸/장기전세 공고 or 당첨자 발표.
+license: MIT
+metadata:
+  category: real-estate
+  locale: ko-KR
+  phase: v1
+---
+
+# SH 청약·주택 공고문 조회
+
+## What this skill does
+
+서울주택도시개발공사(SH, `i-sh.co.kr`)의 공식 **공고 및 공지** 게시판을 조회한다. 요청은 `k-skill-proxy` 의 `/v1/sh-notice/*` 라우트로 보내고, 결과는 목록·상세·첨부 미리보기 링크로 정리한다.
+
+SH 사이트는 LH처럼 공공데이터포털 전용 공고 API가 안정적으로 열려 있지 않아, 프록시가 공식 SH HTML 게시판을 읽고 정규화한다. 본 스킬은 read-only 조회만 한다.
+
+## When to use
+
+- "SH 행복주택 공고 올라온 거 있어?"
+- "서울주택도시공사 장기전세 공고 찾아줘"
+- "i-sh 공공원룸 당첨자 발표 확인해줘"
+- "SH 공고 303994 상세 보여줘"
+- "서울 공공임대 공고 최근 것 정리해줘"
+
+## When not to use
+
+- LH 공고 전용 조회 → `lh-notice-search` 사용
+- GH·iH 등 다른 지방공사 공고
+- 청약 신청 자동화/제출, 로그인 필요한 마이페이지 업무
+- 개별 자격 심사, 당첨 예측, 가점 계산
+
+## Inputs
+
+목록 조회:
+
+- `q` / `keyword` / `srchWord`: 검색어. 예: `행복주택`, `장기전세`, `공공원룸`, `당첨자`.
+- `srchTp` / `searchType`: `title`/`제목` 또는 `content`/`내용`. 비우면 SH 기본 검색 범위를 따른다.
+- `page`: 페이지 번호. 기본 `1`.
+- `pageSize`: 반환 개수. 기본 `10`, 최대 `100`.
+- `multiItmSeq`: SH 게시판 분류. 기본 `2`(공고 및 공지).
+
+상세 조회:
+
+- `seq`: 목록 응답의 `seq` 값. 숫자 필수.
+- `multiItmSeq`: 기본 `2`.
+
+## Default path
+
+`KSKILL_PROXY_BASE_URL` 환경변수가 있으면 그 값, 없으면 기본 `https://k-skill-proxy.nomadamas.org` 를 사용한다.
+
+```bash
+BASE="${KSKILL_PROXY_BASE_URL:-https://k-skill-proxy.nomadamas.org}"
+BASE="${BASE%/}"
+```
+
+## Supported endpoints
+
+### 공고 목록 조회
+
+```http
+GET /v1/sh-notice/search
+```
+
+예시:
+
+```bash
+curl -fsS --get "${BASE}/v1/sh-notice/search" \
+  --data-urlencode 'q=행복주택' \
+  --data-urlencode 'srchTp=title' \
+  --data-urlencode 'pageSize=10'
+```
+
+필터 없이 호출하면 SH 공고/공지 최신 목록을 돌려준다.
+
+### 공고 상세 조회
+
+```http
+GET /v1/sh-notice/detail?seq={게시글번호}
+```
+
+예시:
+
+```bash
+curl -fsS --get "${BASE}/v1/sh-notice/detail" \
+  --data-urlencode 'seq=303994'
+```
+
+## Response shape
+
+### 목록 응답
+
+```json
+{
+  "items": [
+    {
+      "seq": "304022",
+      "number": "1606",
+      "title": "전산작업에 따른 서비스(신한인증서) 이용 안내",
+      "department": "시스템운영부",
+      "registered_date": "2026-05-08",
+      "views": 97,
+      "is_new": true,
+      "detail_url": "https://www.i-sh.co.kr/app/lay2/program/S48T1581C563/www/brd/m_247/view.do?multi_itm_seq=2&seq=304022"
+    }
+  ],
+  "summary": {
+    "page": 1,
+    "page_size": 10,
+    "returned_count": 10,
+    "total_count": 1606
+  },
+  "query": {
+    "srch_word": "행복주택",
+    "srch_tp": "1",
+    "multi_itm_seq": "2"
+  },
+  "proxy": {
+    "name": "k-skill-proxy",
+    "cache": { "hit": false, "ttl_ms": 300000 }
+  }
+}
+```
+
+### 상세 응답
+
+```json
+{
+  "notice": {
+    "seq": "303994",
+    "title": "행복주택 예비당첨자 게시",
+    "registered_date": "2026-05-07",
+    "views": 1972,
+    "content_text": "2022년 2차 행복주택 예비17차 ...",
+    "attachments": [
+      {
+        "filename": "2022년 2차 행복주택 예비 17차 당첨자명단.pdf",
+        "file_seq": "1",
+        "preview_url": "https://www.i-sh.co.kr/app/com/util/htmlConverter.do?...",
+        "download_hint": "https://www.i-sh.co.kr/app/com/file/fileDown.do?..."
+      }
+    ],
+    "detail_url": "https://www.i-sh.co.kr/app/lay2/program/S48T1581C563/www/brd/m_247/view.do?multi_itm_seq=2&seq=303994"
+  },
+  "query": { "seq": "303994", "multi_itm_seq": "2" },
+  "proxy": { "...": "..." }
+}
+```
+
+## Response policy
+
+- 공식 SH 사이트(`www.i-sh.co.kr`) 정보만 사용한다.
+- 목록 결과는 상위 3~5건만 간결히 보여주고, 제목·담당부서·등록일·조회수·공식 링크를 포함한다.
+- 상세 조회에서는 본문 요약과 첨부파일명을 우선 보여준다. 첨부 원문 확인이 중요하면 `preview_url` 을 함께 제시한다.
+- 마감일이 별도 필드로 제공되지 않는 게시판 구조다. 본문/첨부 공고문에 있는 접수기간은 상세 본문을 읽고 별도 추출·요약해야 한다.
+- SH 공고는 LH 공고와 ID 체계가 다르다. `seq` 는 SH 게시글 번호이며 LH `pan_id` 가 아니다.
+
+## Failure modes
+
+- `seq` 가 없거나 숫자가 아니면 `400 bad_request`.
+- SH 사이트가 일시 장애이거나 HTML 구조가 바뀌면 `502 upstream_error` 또는 빈 결과가 내려올 수 있다.
+- `download_hint` 는 SH 파일 다운로드 패턴 추정 URL이다. 공식 미리보기 링크(`preview_url`)가 더 안정적이다.
+
+## Done when
+
+- 사용자의 키워드/공고 유형 의도에 맞춰 `/v1/sh-notice/search` 를 호출했다.
+- 결과에 제목, 담당부서, 등록일, 공식 상세 링크가 포함되어 있다.
+- 상세가 필요하면 목록의 `seq` 로 `/v1/sh-notice/detail` 을 호출해 본문과 첨부파일을 확인했다.


### PR DESCRIPTION
## Summary
- Add SH 공고/공지 list and detail scraper helpers for the official i-sh.co.kr board
- Expose /v1/sh-notice/search and /v1/sh-notice/detail proxy routes with caching and validation
- Add sh-notice-search skill docs and node:test coverage for list/detail parsing

## Verification
- npm run ci
- Live smoke: latest list, keyword title search, pagination, zero-result search, and multiple detail pages with attachments

## Notes
- Production proxy is updated after this reaches main per the repo auto-update flow.