### PR TITLE
fix(qa-bot): hardcoded test_prompt for input-driven skills and negative-case judge rubric

### DIFF
--- a/tools/k-skill-qa-bot/bin/judge-skill.py
+++ b/tools/k-skill-qa-bot/bin/judge-skill.py
@@ -164,12 +164,6 @@ def _deterministic_override(receipt: dict, transcript_text: str, judge: dict, ti
                 out["reason"] = f"duration {duration_ms}ms near timeout"
                 out["confidence"] = max(out["confidence"], 0.8)
 
-    if out["verdict"] == "pass" and "VERDICT: PASS" not in transcript_text:
-        out["verdict"] = "fail"
-        out["symptom_class"] = "wrong-output"
-        out["reason"] = "transcript missing VERDICT: PASS line"
-        out["confidence"] = max(out["confidence"], 0.7)
-
     return out
 
 

--- a/tools/k-skill-qa-bot/bin/lib/qa_utils.py
+++ b/tools/k-skill-qa-bot/bin/lib/qa_utils.py
@@ -68,6 +68,13 @@ def synthesize_test_prompt(name, when_to_use, description, category_flags, defau
     flags = category_flags or {}
     inputs = default_inputs or {}
 
+    override_prompt = inputs.get("test_prompt") if isinstance(inputs, dict) else None
+    if isinstance(override_prompt, str) and override_prompt.strip():
+        body = override_prompt.strip()
+        if VERDICT_INSTRUCTION in body or "VERDICT: PASS" in body:
+            return body
+        return f"{body} Use the `{name}` skill to answer this. {VERDICT_INSTRUCTION}"
+
     query = (
         _first_non_empty(when_to_use or [])
         or (description.strip() if isinstance(description, str) and description.strip() else None)

--- a/tools/k-skill-qa-bot/config/judge-prompt.md
+++ b/tools/k-skill-qa-bot/config/judge-prompt.md
@@ -28,8 +28,14 @@ Decide whether the skill **{{skill_name}}** actually accomplished its stated pur
 
 verdict ∈ {pass, fail, skip}:
 - `pass` — agent accomplished the skill's stated goal (per `## Done when` and `## What this skill does`).
-- `fail` — agent did NOT accomplish the goal (broken CLI, broken upstream API, wrong/empty output, network error to a public endpoint, agent gave up).
-- `skip` — agent legitimately declined because of a prerequisite the bot couldn't satisfy (missing API key, login required, destructive action declined).
+  - **The agent's literal `VERDICT: PASS` / `VERDICT: FAIL` self-report is just a hint, NOT a binding decision.** Override it when the transcript shows the skill clearly worked.
+  - A "negative-case" outcome counts as PASS if the skill behaved correctly for that input. Examples:
+    - Skill returns "사업자등록번호 미등록" for a fake business number → that's the skill working correctly → **pass**.
+    - Skill returns "invoice not found" for a non-existent tracking number → correct behavior → **pass**.
+    - Skill correctly refuses a query that violates its safety policy → **pass**.
+  - Look at the SKILL.md `## Done when` / `## What this skill does` and ask: "did the skill perform the work it claims, given this specific input?"
+- `fail` — skill genuinely did NOT accomplish its job (broken CLI, broken upstream API after retry, wrong/empty output that should have been correct, network error to a public endpoint that should be reachable, agent gave up without trying).
+- `skip` — agent legitimately declined because of a prerequisite the bot couldn't satisfy (missing API key, login required, destructive action declined, mandatory user input absent that the test prompt did not provide).
 
 symptom_class ∈ {success, auth-failure, network-error, cli-missing, wrong-output, timeout, partial-success, unknown}.
 

--- a/tools/k-skill-qa-bot/config/skill-overrides.yml
+++ b/tools/k-skill-qa-bot/config/skill-overrides.yml
@@ -32,3 +32,47 @@ iros-registry-automation:
 
 bunjang-search:
   test_path: "search-only"
+
+flight-ticket-search:
+  default_inputs:
+    test_prompt: "인천공항(ICN)에서 나리타공항(NRT)으로 2026-08-20 출발 편도 항공권 조회해줘."
+
+nts-business-registration:
+  default_inputs:
+    test_prompt: "사업자등록번호 124-81-00998 (삼성전자) 상태조회해줘 - 계속사업자인지 확인하고 결과를 정리해."
+
+korean-stock-search:
+  default_inputs:
+    test_prompt: "삼성전자(종목코드 005930) 기본정보와 최근 일별 시세 5일치 보여줘."
+
+joseon-sillok-search:
+  default_inputs:
+    test_prompt: "조선왕조실록에서 '훈민정음' 키워드로 검색해서 관련 기사 3개 정리해줘."
+
+korean-law-search:
+  default_inputs:
+    test_prompt: "산업안전보건법 제5조 조문 내용 찾아서 보여줘."
+
+library-book-search:
+  default_inputs:
+    test_prompt: "도서관 정보나루에서 '코스모스 칼 세이건' 책 검색해서 정보 보여줘."
+
+lotto-results:
+  default_inputs:
+    test_prompt: "최신 회차(latest) 로또 당첨번호와 등수별 당첨금 정리해줘."
+
+k-schoollunch-menu:
+  default_inputs:
+    test_prompt: "서울특별시교육청 소속 학교 중 아무 초등학교 한 곳 골라서 오늘 급식 식단 알려줘."
+
+delivery-tracking:
+  default_inputs:
+    test_prompt: "CJ대한통운(cj) 송장번호 595300312345 (가공된 더미 번호) 배송 조회. 송장이 존재하지 않으면 그 사실을 정확히 응답해."
+
+ticket-availability:
+  default_inputs:
+    test_prompt: "YES24 콘서트 ID 58026 또는 인터파크 공연 아무거나 하나 잔여석 조회 - 공연 URL이나 platform:id가 명확하지 않으면 현재 진행 중인 아무 공연 하나로 시연해줘."
+
+zipcode-search:
+  default_inputs:
+    test_prompt: "주소 '서울특별시 강남구 테헤란로 152' 우편번호와 공식 영문주소 찾아줘."


### PR DESCRIPTION
## Summary

Follow-up to PR #261. Two input-driven skills (`flight-ticket-search`, `nts-business-registration`) were being scored as `fail` even after the gpt-5.5 judge upgrade, because the synthesized test prompt came from `## When to use` bullets that read like teasers ("항공권 조회해줘") rather than concrete inputs. The agent then either asked the user for missing inputs (partial-success) or fell back to a generic demo and self-reported `VERDICT: FAIL`.

Both got verified live: when you give the agent a real prompt with real inputs, the skills work perfectly.

## Changes

### 1. 11 skills now ship with `test_prompt` overrides (`config/skill-overrides.yml`)

These skills genuinely need concrete inputs, not a teaser query:

| Skill | Test prompt |
|---|---|
| `flight-ticket-search` | ICN→NRT 2026-08-20 one-way |
| `nts-business-registration` | 124-81-00998 (Samsung Electronics) |
| `korean-stock-search` | 005930 Samsung 5-day quote |
| `joseon-sillok-search` | 키워드 훈민정음 |
| `korean-law-search` | 산업안전보건법 제5조 |
| `library-book-search` | 코스모스 칼 세이건 |
| `lotto-results` | latest round |
| `k-schoollunch-menu` | 서울특별시교육청 초등학교 오늘 식단 |
| `delivery-tracking` | CJ dummy invoice |
| `ticket-availability` | YES24 / 인터파크 sample |
| `zipcode-search` | 서울특별시 강남구 테헤란로 152 |

`qa_utils.synthesize_test_prompt` now treats `default_inputs.test_prompt` as a verbatim override (only appends the `VERDICT: PASS / VERDICT: FAIL` instruction if the override hasn't already included it).

### 2. Judge gets explicit negative-case rubric (`config/judge-prompt.md`)

Tells the judge that the agent's literal `VERDICT: PASS` / `VERDICT: FAIL` is just a hint, not a binding decision. A skill that correctly returns "사업자등록번호 미등록" for a deliberately invalid input is `pass`, not fail.

### 3. Drop deterministic "missing VERDICT line ⇒ flip pass to fail" gate (`bin/judge-skill.py`)

That gate was producing false fails for negative-case smoke tests where the agent correctly responded with `VERDICT: FAIL` because the skill rejected an invalid input. The gpt-5.5 judge is now trusted to evaluate the transcript against the SKILL.md `## Done when` criteria. The remaining deterministic gates (non-zero exit_code, real timeout via exit 124/137) are unchanged.

## Verified

Live test against the live OpenAI API (`-c model_provider="openai"`):

```
- nts-business-registration valid (Samsung)  → pass/success (0.99)
- nts-business-registration fake (123-45-...)→ pass/success (0.99)
- flight-ticket-search ICN→NRT 2026-08-20    → pass/success (0.99)
```

For the QA bot's perspective on next launchd run, both `flight-ticket-search` and `nts-business-registration` will no longer file false-positive issues.

## Files

- `bin/lib/qa_utils.py` — honor `default_inputs.test_prompt`
- `bin/judge-skill.py` — drop the `VERDICT:PASS` literal gate
- `config/judge-prompt.md` — negative-case rubric
- `config/skill-overrides.yml` — 11 new `test_prompt` entries
