### PR TITLE
ci(deploy): naverMapConfigured smoke test 예외 처리

### DIFF
--- a/.github/workflows/deploy-k-skill-proxy.yml
+++ b/.github/workflows/deploy-k-skill-proxy.yml
@@ -126,10 +126,15 @@ jobs:
           if not data.get('ok'):
               print('Health response is not ok:', data)
               sys.exit(1)
-          missing = [k for k, v in data.get('upstreams', {}).items() if k.endswith('Configured') and v is not True]
+          # naverMapConfigured is expected to be false until NCP Maps keys are provisioned
+          KNOWN_UNCONFIGURED = {'naverMapConfigured'}
+          missing = [k for k, v in data.get('upstreams', {}).items() if k.endswith('Configured') and v is not True and k not in KNOWN_UNCONFIGURED]
           if missing:
               print('Upstreams not configured:', missing)
               sys.exit(1)
+          skipped = [k for k in KNOWN_UNCONFIGURED if not data.get('upstreams', {}).get(k)]
+          if skipped:
+              print(f'Note: {skipped} not yet configured (expected, see docs/features/naver-map-route.md)')
           print('Health OK. All upstreams configured.')
           "
 


### PR DESCRIPTION
## Summary

PR #285 머지 후 Cloud Run 배포 시 smoke test가 `naverMapConfigured: false` 때문에 실패함.

실제 배포 자체는 성공 (프로덕션 라이브 동작 중), smoke test 검증 단계에서만 fail.

### 원인
- 배포 워크플로의 smoke test가 `/health` 응답의 **모든** `*Configured` 플래그가 `true`인지 검사
- `NAVER_MAP_CLIENT_ID`/`SECRET`이 Secret Manager에 아직 없으므로 `naverMapConfigured: false`

### 수정 내용
- `KNOWN_UNCONFIGURED` set에 `naverMapConfigured` 추가
- 해당 플래그는 smoke test에서 예외 처리 (fail 대신 note 출력)
- NCP 결제수단 등록 → 키 설정 완료 후 이 예외를 제거할 것

### 확인
- 프로덕션 `/health` 정상 응답: `ok: true`, 카카오맵 라우트 포함 모든 기존 upstream `true`