### PR TITLE
feat(daangn-realty-search): expose listing release_date

### DIFF
--- a/daangn-realty-search/SKILL.md
+++ b/daangn-realty-search/SKILL.md
@@ -92,7 +92,9 @@ python3 ... detail "https://realty.daangn.com/articles/2947028"
 
 ## Output fields
 
-매물: `article_id, salesType, area_sqm, area_pyeong, trades[{type,label,deposit_manwon,monthly_manwon,price_manwon,per_pyeong_manwon}], url, region, title, address, floor_label, nearby_subway`
+매물: `article_id, salesType, area_sqm, area_pyeong, trades[{type,label,deposit_manwon,monthly_manwon,price_manwon,per_pyeong_manwon}], url, region, title, address, floor_label, nearby_subway, release_date`
+
+`release_date`는 상세 페이지 JSON-LD의 `Product.releaseDate`(ISO 8601, UTC)이며 `--titles` 보강 대상 매물에만 채워진다. 최초 등록일인지 최근 끌어올리기/수정일인지는 당근 쪽 명세에 없어 확정할 수 없다.
 
 ## Region handling
 

--- a/daangn-realty-search/scripts/daangn_detail_ld.py
+++ b/daangn-realty-search/scripts/daangn_detail_ld.py
@@ -12,6 +12,7 @@ def parse_detail(url, fetch_text):
         "top_floor": None,
         "floor_label": None,
         "nearby_subway": None,
+        "release_date": None,
         "json_ld": [],
     }
     scripts = re.findall(
@@ -51,6 +52,7 @@ def _apply_node(out, node):
         return
     if node.get("@type") == "Product" and not out["title"]:
         out["title"] = node.get("name")
+        out["release_date"] = node.get("releaseDate")
     if node.get("@type") == "Place" and not out["address"]:
         out["address"] = node.get("name")
     for prop in _properties(node.get("additionalProperty")):

--- a/daangn-realty-search/scripts/daangn_detail_ld.py
+++ b/daangn-realty-search/scripts/daangn_detail_ld.py
@@ -50,9 +50,11 @@ def _json_ld_nodes(document):
 def _apply_node(out, node):
     if not isinstance(node, dict):
         return
-    if node.get("@type") == "Product" and not out["title"]:
-        out["title"] = node.get("name")
-        out["release_date"] = node.get("releaseDate")
+    if node.get("@type") == "Product":
+        if not out["title"]:
+            out["title"] = node.get("name")
+        if not out["release_date"]:
+            out["release_date"] = node.get("releaseDate")
     if node.get("@type") == "Place" and not out["address"]:
         out["address"] = node.get("name")
     for prop in _properties(node.get("additionalProperty")):

--- a/daangn-realty-search/scripts/daangn_realty.py
+++ b/daangn-realty-search/scripts/daangn_realty.py
@@ -170,6 +170,7 @@ def cmd_search(args):
                 it["address"] = d.get("address")
                 it["floor_label"] = d.get("floor_label")
                 it["nearby_subway"] = d.get("nearby_subway")
+                it["release_date"] = d.get("release_date")
             except (json.JSONDecodeError, OSError, TimeoutError, urllib.error.URLError):
                 pass
 

--- a/scripts/test_daangn_realty.py
+++ b/scripts/test_daangn_realty.py
@@ -135,6 +135,22 @@ class DetailParsingTest(unittest.TestCase):
 
         self.assertIsNone(detail["release_date"])
 
+    def test_parse_detail_extracts_release_date_from_later_product_node(self):
+        html = """
+        <script type="application/ld+json">
+        {"@graph":[
+          {"@type":"Product","name":"상가 월세"},
+          {"@type":"Product","name":"상가 월세","releaseDate":"2026-07-05T09:12:33.000Z"}
+        ]}
+        </script>
+        """
+
+        with mock.patch.object(daangn_realty, "fetch_text", return_value=html):
+            detail = daangn_realty.parse_detail("https://realty.daangn.com/articles/789")
+
+        self.assertEqual(detail["title"], "상가 월세")
+        self.assertEqual(detail["release_date"], "2026-07-05T09:12:33.000Z")
+
 
 class SearchEnrichmentTest(unittest.TestCase):
     def test_cmd_search_enriches_items_with_release_date(self):

--- a/scripts/test_daangn_realty.py
+++ b/scripts/test_daangn_realty.py
@@ -104,7 +104,7 @@ class DetailParsingTest(unittest.TestCase):
         <script type="application/ld+json">{"@context":"https://schema.org","@graph":null}</script>
         <script type="application/ld+json">
         {"@graph":[
-          {"@type":"Product","name":"상가 월세","additionalProperty":[
+          {"@type":"Product","name":"상가 월세","releaseDate":"2026-07-02T11:34:38.149Z","additionalProperty":[
             {"name":"floor","value":"8.0"},
             {"name":"topFloor","value":"10"},
             {"name":"nearbySubwayStation","value":"매교역"}
@@ -121,6 +121,87 @@ class DetailParsingTest(unittest.TestCase):
         self.assertEqual(detail["address"], "경기도 수원시 팔달구 매교동")
         self.assertEqual(detail["floor_label"], "8층/10층")
         self.assertEqual(detail["nearby_subway"], "매교역")
+        self.assertEqual(detail["release_date"], "2026-07-02T11:34:38.149Z")
+
+    def test_parse_detail_defaults_release_date_to_none_when_absent(self):
+        html = """
+        <script type="application/ld+json">
+        {"@graph":[{"@type":"Product","name":"매매"}]}
+        </script>
+        """
+
+        with mock.patch.object(daangn_realty, "fetch_text", return_value=html):
+            detail = daangn_realty.parse_detail("https://realty.daangn.com/articles/456")
+
+        self.assertIsNone(detail["release_date"])
+
+
+class SearchEnrichmentTest(unittest.TestCase):
+    def test_cmd_search_enriches_items_with_release_date(self):
+        store = {
+            "card:1": {"__typename": "ArticleFeedCard", "article": {"__ref": "article:1"}},
+            "article:1": {
+                "__typename": "Article",
+                "originalId": "123",
+                "area": "33.05785",
+                "salesTypeV3": {"__ref": "sales:1"},
+                "trades": {"__refs": ["trade:month"]},
+            },
+            "sales:1": {"__typename": "ArticleSalesTypeV2", "type": "STORE"},
+            "trade:month": {"__typename": "MonthTrade", "deposit": "1000", "monthlyPay": "50"},
+        }
+        detail_html = """
+        <script type="application/ld+json">
+        {"@graph":[{"@type":"Product","name":"상가 월세","releaseDate":"2026-07-02T11:34:38.149Z"}]}
+        </script>
+        """
+
+        def fake_fetch_text(url):
+            if "articles" in url:
+                return detail_html
+            return relay_html(store)
+
+        args = daangn_realty.build_parser().parse_args(
+            ["search", "--region", "매교동", "--limit", "5", "--titles", "5"]
+        )
+
+        with mock.patch.object(
+            daangn_realty, "resolve_region",
+            return_value={"name1": "경기도", "name2": "수원시 팔달구", "name3": "매교동"},
+        ), mock.patch.object(daangn_realty, "fetch_text", side_effect=fake_fetch_text), \
+                mock.patch("builtins.print") as mock_print:
+            daangn_realty.cmd_search(args)
+
+        printed = json.loads(mock_print.call_args[0][0])
+        self.assertEqual(printed["items"][0]["release_date"], "2026-07-02T11:34:38.149Z")
+
+    def test_cmd_search_leaves_release_date_absent_when_titles_disabled(self):
+        store = {
+            "card:1": {"__typename": "ArticleFeedCard", "article": {"__ref": "article:1"}},
+            "article:1": {
+                "__typename": "Article",
+                "originalId": "123",
+                "area": "33.05785",
+                "salesTypeV3": {"__ref": "sales:1"},
+                "trades": {"__refs": ["trade:month"]},
+            },
+            "sales:1": {"__typename": "ArticleSalesTypeV2", "type": "STORE"},
+            "trade:month": {"__typename": "MonthTrade", "deposit": "1000", "monthlyPay": "50"},
+        }
+
+        args = daangn_realty.build_parser().parse_args(
+            ["search", "--region", "매교동", "--limit", "5", "--titles", "0"]
+        )
+
+        with mock.patch.object(
+            daangn_realty, "resolve_region",
+            return_value={"name1": "경기도", "name2": "수원시 팔달구", "name3": "매교동"},
+        ), mock.patch.object(daangn_realty, "fetch_text", return_value=relay_html(store)), \
+                mock.patch("builtins.print") as mock_print:
+            daangn_realty.cmd_search(args)
+
+        printed = json.loads(mock_print.call_args[0][0])
+        self.assertNotIn("release_date", printed["items"][0])
 
 
 class CliCompatibilityTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Extract `Product.releaseDate` from the article detail page JSON-LD and surface it as `release_date` on search items enriched via `--titles`.
- Documented the field (and its uncertainty as first-post-date vs bump-date) in `daangn-realty-search/SKILL.md`.

## Test plan
- [x] `python3 -m unittest scripts.test_daangn_realty` (8 tests, all passing, including 4 new tests covering the new field and the `--titles 0` no-enrichment case)
- [x] Manual smoke: `python3 daangn-realty-search/scripts/daangn_realty.py search --region "창원시 의창구 북면" --titles 3` returns `release_date` for enriched items