### PR TITLE
[codex] Fix g2b order-plan service key casing

### DIFF
--- a/packages/k-skill-proxy/src/g2b-order-plan.js
+++ b/packages/k-skill-proxy/src/g2b-order-plan.js
@@ -216,7 +216,7 @@ function extractOrderPlanItems(payload) {
 }
 
 function appendParams(url, params, serviceKey) {
-  url.searchParams.set("serviceKey", serviceKey);
+  url.searchParams.set("ServiceKey", serviceKey);
   url.searchParams.set("type", "json");
   for (const [key, value] of Object.entries(params)) {
     if (["kind", "operation"].includes(key)) continue;

--- a/packages/k-skill-proxy/test/g2b-order-plan.test.js
+++ b/packages/k-skill-proxy/test/g2b-order-plan.test.js
@@ -100,7 +100,8 @@ test("g2b order-plans route proxies search to the selected PPS operation and cac
   assert.equal(body.items[0].bizNm, "청소 용역");
   assert.equal(body.query.operation, "getOrderPlanSttusListServcPPSSrch");
   assert.match(seenUrls[0], /OrderPlanSttusService\/getOrderPlanSttusListServcPPSSrch/);
-  assert.match(seenUrls[0], /serviceKey=data-go-key/);
+  assert.match(seenUrls[0], /ServiceKey=data-go-key/);
+  assert.doesNotMatch(seenUrls[0], /[?&]serviceKey=/);
   assert.match(seenUrls[0], /bizNm=%EC%B2%AD%EC%86%8C/);
 
   const cached = await app.inject({ method: "GET", url });


### PR DESCRIPTION
## Summary

- Fix `/v1/g2b/order-plans` to send the data.go.kr key as `ServiceKey`, matching the G2B/data.go.kr convention and the existing sanctioned-supplier route.
- Lock the behavior with a regression assertion that rejects lowercase `serviceKey` on the order-plan upstream URL.

## Root cause

The order-plan wrapper used lowercase `serviceKey` while the adjacent G2B sanctioned-supplier wrapper and other data.go.kr endpoints use capital-S `ServiceKey`. That produced an upstream URL that could be rejected before returning normal JSON, surfacing to users as the hosted proxy 502 reported in #397.

## Validation

- `node --test packages/k-skill-proxy/test/g2b-order-plan.test.js`
- `npm run lint -w packages/k-skill-proxy`
- `npm test -w packages/k-skill-proxy` (295 passed)
- Local HTTP route + Python CLI smoke against a fake upstream confirmed the patched proxy builds `...OrderPlanSttusService/getOrderPlanSttusListServcPPSSrch?ServiceKey=...` and returns 200.

## Operational note

The hosted `/health` endpoint currently responds, but the hosted `/v1/g2b/order-plans` route was still returning Cloudflare 502 before this patch was deployed. After merge/deploy, rerun the issue #397 reproduction against the hosted proxy.

Closes #397
