### PR TITLE
feat(kosis-stats): add list, explain, indicator subcommands for full 7/7 KOSIS API coverage

### DIFF
--- a/kosis-stats/SKILL.md
+++ b/kosis-stats/SKILL.md
@@ -22,6 +22,9 @@ metadata:
 - `statisticsData.do?method=getMeta` — 통계표 메타데이터 (분류·항목·단위)
 - `statisticsParameterData.do` — 통계표 데이터 셀 조회 (기간/분류 필터)
 - `statisticsBigData.do` — 대용량 자료 (사전 등록한 `userStatsId` 필요)
+- `statisticsList.do` — 통계목록 카테고리 트리 탐색 (주제별/기관별/국제통계/북한통계 등)
+- `statisticsExplData.do` — 통계설명 (조사목적·주기·대상·법적근거·공표방법 등 27개 항목)
+- `pkNumberService.do` — 통계주요지표 (1,473개 핵심 지표의 개념·산정방법·출처)
 
 ## When to use
 
@@ -29,6 +32,9 @@ metadata:
 - "KOSIS에서 고령인구 비율 시도별 데이터 가져와"
 - "DT_1IN0001 표 메타데이터 보여줘"
 - "최근 5년치 소비자물가지수 KOSIS에서 뽑아줘"
+- "국내통계 주제별로 어떤 카테고리가 있어?" (`list`)
+- "인구총조사 조사목적·조사주기 알려줘" (`explain`)
+- "인구밀도 지표 산정방법 보여줘" (`indicator`)
 
 ## When not to use
 
@@ -40,7 +46,7 @@ metadata:
 ## Prerequisites
 
 - Python 3.9+ (stdlib only, 외부 패키지 없음)
-- 일반 `search`/`meta`/`data`: `k-skill-proxy`의 KOSIS route가 있는 hosted/self-host 프록시에 접근 가능할 것
+- 일반 `search`/`meta`/`data`/`list`/`explain`/`indicator`: `k-skill-proxy`의 KOSIS route가 있는 hosted/self-host 프록시에 접근 가능할 것
 - `bigdata` 또는 `--direct`: KOSIS Open API 인증키 (무료, https://kosis.kr/openapi/ 에서 회원가입 후 활용신청)
 
 ```bash
@@ -49,7 +55,7 @@ python3 kosis-stats/scripts/run_kosis_stats.py --help
 
 ## Required environment variables
 
-- 일반 `search`/`meta`/`data`: 없음. 기본 hosted `https://k-skill-proxy.nomadamas.org` 를 사용한다.
+- 일반 `search`/`meta`/`data`/`list`/`explain`/`indicator`: 없음. 기본 hosted `https://k-skill-proxy.nomadamas.org` 를 사용한다.
 - `KSKILL_PROXY_BASE_URL` — self-host·별도 프록시를 쓸 때만 설정. 비우면 기본 hosted proxy를 사용한다.
 - `KSKILL_KOSIS_API_KEY` — `bigdata` 또는 `--direct`로 KOSIS를 직접 호출할 때만 필요하다.
 
@@ -64,10 +70,11 @@ python3 kosis-stats/scripts/run_kosis_stats.py --help
 
 기본 경로에 저장하는 것은 fallback일 뿐, 강제가 아니다.
 일반 조회 helper는 proxy URL만 읽고, KOSIS 인증키는 proxy 서버에서만 주입한다. `bigdata`/`--direct` 호출만 `KSKILL_KOSIS_API_KEY` 환경변수와 위 secrets 파일을 읽는다.
+`list`/`explain`/`indicator`는 `search`/`meta`/`data`와 마찬가지로 proxy 경유로 동작한다.
 
 ## Inputs
 
-서브커맨드: `search`, `meta`, `data`, `bigdata`.
+서브커맨드: `search`, `meta`, `data`, `bigdata`, `list`, `explain`, `indicator`.
 
 공통 옵션:
 
@@ -99,6 +106,16 @@ python3 kosis-stats/scripts/run_kosis_stats.py --help
   - `--user-stats-id <KOSIS 등록 ID>`
   - `--format json|sdmx|csv` (xls는 바이너리라 helper 미지원 — 필요 시 KOSIS 웹에서 직접 다운로드)
   - `--prd-se`, `--new-est-prd-cnt` (선택)
+- `list`
+  - `--vw-cd MT_ZTITLE|MT_OTITLE|MT_GTITLE01|MT_GTITLE02|MT_CHOSUN_TITLE|MT_HANKUK_TITLE|MT_STOP_TITLE|MT_RTITLE|MT_BUKHAN|MT_TM1_TITLE|MT_TM2_TITLE|MT_ETITLE` (필수)
+  - `--parent-id <LIST_ID>` (하위 카테고리 탐색, 기본 빈 문자열=최상위)
+- `explain`
+  - `--stat-id <통계조사ID>` (단독) 또는 `--org-id 101 --table-id DT_1IN0001` (조합, 둘 중 하나 필수)
+  - `--meta-itm All|statsNm,statsKind,...` (기본 All)
+- `indicator`
+  - `--jipyo-id 160` (필수, 지표ID)
+  - `--service 1|2|3` (기본 1: 1=개념, 2=산정방법·출처, 3=전체설명)
+  - `--page-no N`, `--num-of-rows N` (페이징)
 
 ## Workflow
 

--- a/kosis-stats/scripts/run_kosis_stats.py
+++ b/kosis-stats/scripts/run_kosis_stats.py
@@ -30,6 +30,9 @@ SEARCH_URL = "https://kosis.kr/openapi/statisticsSearch.do"
 META_URL = "https://kosis.kr/openapi/statisticsData.do"
 DATA_URL = "https://kosis.kr/openapi/Param/statisticsParameterData.do"
 BIGDATA_URL = "https://kosis.kr/openapi/statisticsBigData.do"
+LIST_URL = "https://kosis.kr/openapi/statisticsList.do"
+EXPLAIN_URL = "https://kosis.kr/openapi/statisticsExplData.do"
+INDICATOR_URL = "https://kosis.kr/openapi/pkNumberService.do"
 PROXY_BASE_URL_ENV_VAR = "KSKILL_PROXY_BASE_URL"
 DEFAULT_PROXY_BASE_URL = "https://k-skill-proxy.nomadamas.org"
 
@@ -39,6 +42,16 @@ PRD_SE_VALUES = {"M", "Q", "S", "Y", "F", "IR"}
 # but the helper streams text-only output. Use bigdata json/sdmx/csv (text)
 # for now; download xls files manually from the KOSIS web UI if you need them.
 BIGDATA_FORMATS = {"json", "sdmx", "csv"}
+
+# statisticsList.do service view codes
+VIEW_CODES = {
+    "MT_ZTITLE", "MT_OTITLE", "MT_GTITLE01", "MT_GTITLE02",
+    "MT_CHOSUN_TITLE", "MT_HANKUK_TITLE", "MT_STOP_TITLE",
+    "MT_RTITLE", "MT_BUKHAN", "MT_TM1_TITLE", "MT_TM2_TITLE", "MT_ETITLE",
+}
+
+# pkNumberService.do sub-services
+INDICATOR_SERVICES = {"1", "2", "3"}
 
 ERROR_CODE_HINTS: dict[str, str] = {
     "10": "인증키가 누락되었습니다. KSKILL_KOSIS_API_KEY 환경변수를 확인하세요.",
@@ -92,6 +105,23 @@ def parse_bigdata_format(value: str) -> str:
             "must be one of: " + ", ".join(sorted(BIGDATA_FORMATS))
         )
     return lower
+
+
+def parse_view_code(value: str) -> str:
+    upper = value.strip().upper()
+    if upper not in VIEW_CODES:
+        raise argparse.ArgumentTypeError(
+            "must be one of: " + ", ".join(sorted(VIEW_CODES))
+        )
+    return upper
+
+
+def parse_indicator_service(value: str) -> str:
+    if value not in INDICATOR_SERVICES:
+        raise argparse.ArgumentTypeError(
+            "must be one of: " + ", ".join(sorted(INDICATOR_SERVICES))
+        )
+    return value
 
 
 def _add_common_flags(parser: argparse.ArgumentParser) -> None:
@@ -206,6 +236,71 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--new-est-prd-cnt",
         type=int,
         help="Count of latest periods to fetch (alternative to start/end).",
+    )
+
+    list_cmd = sub.add_parser(
+        "list",
+        help="Browse statistical table categories (statisticsList.do).",
+    )
+    _add_common_flags(list_cmd)
+    list_cmd.add_argument(
+        "--vw-cd",
+        type=parse_view_code,
+        required=True,
+        help="Service view code: MT_ZTITLE(국내통계주제별) MT_OTITLE(기관별) "
+        "MT_GTITLE01/02(e-지방지표) MT_RTITLE(국제통계) MT_BUKHAN(북한통계) etc.",
+    )
+    list_cmd.add_argument(
+        "--parent-id",
+        default="",
+        help="Parent list ID for sub-categories. Empty string = top-level.",
+    )
+
+    explain = sub.add_parser(
+        "explain",
+        help="Fetch statistical survey description (statisticsExplData.do).",
+    )
+    _add_common_flags(explain)
+    explain.add_argument(
+        "--stat-id",
+        help="Statistics survey ID (alternative to --org-id/--table-id).",
+    )
+    explain.add_argument("--org-id", help="Organization ID (with --table-id).")
+    explain.add_argument("--table-id", help="KOSIS table ID (with --org-id).")
+    explain.add_argument(
+        "--meta-itm",
+        default="All",
+        help="Requested field(s): All(전체) or comma-separated list "
+        "(statsNm,statsKind,writingPurps,...). Default All.",
+    )
+
+    indicator = sub.add_parser(
+        "indicator",
+        help="Fetch key indicator metadata (pkNumberService.do).",
+    )
+    _add_common_flags(indicator)
+    indicator.add_argument(
+        "--service",
+        type=parse_indicator_service,
+        default="1",
+        help="Sub-service: 1(개념) 2(산정방법·출처) 3(전체설명). Default 1.",
+    )
+    indicator.add_argument(
+        "--jipyo-id",
+        required=True,
+        help="Indicator ID (e.g. 160).",
+    )
+    indicator.add_argument(
+        "--page-no",
+        type=int,
+        default=1,
+        help="Page number (default 1).",
+    )
+    indicator.add_argument(
+        "--num-of-rows",
+        type=int,
+        default=10,
+        help="Rows per page (default 10).",
     )
 
     return parser.parse_args(argv)
@@ -331,6 +426,52 @@ def build_bigdata_params(api_key: str, args: argparse.Namespace) -> dict[str, st
     if args.new_est_prd_cnt is not None:
         params["newEstPrdCnt"] = str(args.new_est_prd_cnt)
     return params
+
+
+def build_list_params(api_key: str, args: argparse.Namespace) -> dict[str, str]:
+    return {
+        "method": "getList",
+        "apiKey": api_key,
+        "format": "json",
+        "jsonVD": "Y",
+        "vwCd": args.vw_cd,
+        "parentId": args.parent_id,
+    }
+
+
+def build_explain_params(api_key: str, args: argparse.Namespace) -> dict[str, str]:
+    params: dict[str, str] = {
+        "method": "getList",
+        "apiKey": api_key,
+        "format": "json",
+        "jsonVD": "Y",
+        "metaItm": args.meta_itm,
+    }
+    if args.stat_id:
+        params["statId"] = args.stat_id
+    elif args.org_id and args.table_id:
+        params["orgId"] = args.org_id
+        params["tblId"] = args.table_id
+    else:
+        raise SystemExit(
+            "explain requires either --stat-id or both --org-id and --table-id."
+        )
+    return params
+
+
+def build_indicator_params(api_key: str, args: argparse.Namespace) -> dict[str, str]:
+    return {
+        "method": "getList",
+        "apiKey": api_key,
+        "format": "json",
+        "jsonVD": "Y",
+        "service": args.service,
+        "serviceDetail": "pkNotion" if args.service == "1" else "pkCalcSource"
+        if args.service == "2" else "pkAll",
+        "jipyoId": args.jipyo_id,
+        "pageNo": str(args.page_no),
+        "numOfRows": str(args.num_of_rows),
+    }
 
 
 def build_url(base: str, params: dict[str, str]) -> str:
@@ -500,6 +641,110 @@ def render_data_text(payload: Any) -> str:
     return "\n".join(lines)
 
 
+_EXPLAIN_FIELD_LABELS: dict[str, str] = {
+    "statsNm": "조사명",
+    "statsKind": "작성유형",
+    "statsEnd": "통계종류",
+    "statsContinue": "계속여부",
+    "basisLaw": "법적근거",
+    "writingPurps": "조사목적",
+    "examinPd": "조사기간",
+    "statsPeriod": "조사주기",
+    "writingSystem": "조사체계",
+    "writingTel": "연락처",
+    "statsField": "통계분야·실태",
+    "examinObjrange": "조사대상범위",
+    "examinObjArea": "조사대상지역",
+    "josaUnit": "조사단위·규모",
+    "applyGroup": "적용분류",
+    "josaItm": "조사항목",
+    "pubPeriod": "공표주기",
+    "pubExtent": "공표범위",
+    "pubDate": "공표시기",
+    "publictMth": "공표방법/URL",
+    "examinTrgetPd": "조사대상기간/기준시점",
+    "dataUserNote": "자료이용시 유의사항",
+    "mainTermExpl": "주요 용어해설",
+    "dataCollectMth": "자료 수집방법",
+    "examinHistory": "조사연혁",
+    "confmNo": "승인번호",
+    "confmDt": "승인일자",
+}
+
+
+def render_list_text(payload: Any) -> str:
+    if not isinstance(payload, list) or not payload:
+        return (
+            "조회 결과가 없습니다. --parent-id 를 비워 최상위 카테고리를 보거나, "
+            "다른 --vw-cd (서비스뷰 코드)를 시도하세요."
+        )
+    lines: list[str] = []
+    for entry in payload:
+        if not isinstance(entry, dict):
+            continue
+        list_id = entry.get("LIST_ID", "")
+        list_nm = entry.get("LIST_NM", "?")
+        org_id = entry.get("ORG_ID", "")
+        tbl_id = entry.get("TBL_ID", "")
+        tbl_nm = entry.get("TBL_NM", "")
+        send_de = entry.get("SEND_DE", "")
+        if tbl_id:
+            lines.append(f"- [{list_id}] {list_nm} → [{org_id}/{tbl_id}] {tbl_nm} (갱신: {send_de})")
+        else:
+            lines.append(f"- [{list_id}] {list_nm}")
+    lines.append(
+        "\nNext: 하위 카테고리는 `list --vw-cd <코드> --parent-id <LIST_ID>`. "
+        "통계표는 `meta --table-id <TBL_ID>` 또는 `data --table-id <TBL_ID> ...`."
+    )
+    return "\n".join(lines)
+
+
+def render_explain_text(payload: Any) -> str:
+    if not isinstance(payload, list) or not payload:
+        return (
+            "설명 정보가 없습니다. statId 또는 orgId+tblId 를 재확인하세요. "
+            "`search --query <키워드>` 로 정확한 ID를 찾을 수 있습니다."
+        )
+    lines: list[str] = []
+    for entry in payload:
+        if not isinstance(entry, dict):
+            continue
+        lines.append("---")
+        for field, label in _EXPLAIN_FIELD_LABELS.items():
+            value = entry.get(field, "")
+            if value:
+                lines.append(f"{label}: {value}")
+    if len(lines) == 1 and lines[0] == "---":
+        return "설명 정보 필드가 모두 비어 있습니다. 다른 --meta-itm 을 시도하세요."
+    return "\n".join(lines)
+
+
+def render_indicator_text(payload: Any) -> str:
+    if not isinstance(payload, list) or not payload:
+        return (
+            "지표 정보가 없습니다. --jipyo-id 를 확인하세요. "
+            "KOSIS 개발가이드에서 사용 가능한 지표ID 목록을 볼 수 있습니다."
+        )
+    lines: list[str] = []
+    for entry in payload:
+        if not isinstance(entry, dict):
+            continue
+        jipyo_id = entry.get("statJipyoId", entry.get("jipyoId", "?"))
+        jipyo_nm = entry.get("statJipyoNm", entry.get("jipyoNm", "?"))
+        title = entry.get("jipyoExplan", "")
+        concept = entry.get("jipyoExplan1", entry.get("jipyoCalc", ""))
+        lines.append(f"- [{jipyo_id}] {jipyo_nm}")
+        if title:
+            lines.append(f"  제목: {title}")
+        if concept:
+            # Truncate long text fields
+            display = concept[:500] if len(concept) > 500 else concept
+            lines.append(f"  내용: {display}")
+            if len(concept) > 500:
+                lines.append(f"  ... ({len(concept) - 500}자 생략, --json으로 전체)")
+    return "\n".join(lines)
+
+
 def render_text(command: str, payload: Any) -> str:
     if command == "search":
         return render_search_text(payload)
@@ -507,6 +752,12 @@ def render_text(command: str, payload: Any) -> str:
         return render_meta_text(payload)
     if command == "data":
         return render_data_text(payload)
+    if command == "list":
+        return render_list_text(payload)
+    if command == "explain":
+        return render_explain_text(payload)
+    if command == "indicator":
+        return render_indicator_text(payload)
     return json.dumps(payload, ensure_ascii=False, indent=2)
 
 
@@ -516,11 +767,14 @@ def cite_endpoint(command: str) -> str:
         "meta": META_URL,
         "data": DATA_URL,
         "bigdata": BIGDATA_URL,
+        "list": LIST_URL,
+        "explain": EXPLAIN_URL,
+        "indicator": INDICATOR_URL,
     }[command]
 
 
 def should_use_proxy(args: argparse.Namespace) -> bool:
-    return args.command in {"search", "meta", "data"} and not args.direct
+    return args.command in {"search", "meta", "data", "list", "explain", "indicator"} and not args.direct
 
 
 def proxy_endpoint(command: str, base_url: str) -> str:
@@ -528,6 +782,9 @@ def proxy_endpoint(command: str, base_url: str) -> str:
         "search": "/v1/kosis/search",
         "meta": "/v1/kosis/meta",
         "data": "/v1/kosis/data",
+        "list": "/v1/kosis/list",
+        "explain": "/v1/kosis/explain",
+        "indicator": "/v1/kosis/indicator",
     }[command]
     return f"{base_url.rstrip('/')}{path}"
 
@@ -551,6 +808,9 @@ def run(args: argparse.Namespace) -> int:
         "meta": build_meta_params,
         "data": build_data_params,
         "bigdata": build_bigdata_params,
+        "list": build_list_params,
+        "explain": build_explain_params,
+        "indicator": build_indicator_params,
     }[args.command]
     base = cite_endpoint(args.command)
     params = builder(api_key, args)

--- a/kosis-stats/tests/test_run_kosis_stats.py
+++ b/kosis-stats/tests/test_run_kosis_stats.py
@@ -71,6 +71,34 @@ class ParseArgsTest(unittest.TestCase):
                 "search", "--query", "x", "--result-count", "9999",
             ])
 
+    def test_list_subcommand_parses_vw_cd(self):
+        args = helper.parse_args(["list", "--vw-cd", "MT_ZTITLE"])
+        self.assertEqual(args.command, "list")
+        self.assertEqual(args.vw_cd, "MT_ZTITLE")
+        self.assertEqual(args.parent_id, "")
+
+    def test_list_invalid_vw_cd_rejected(self):
+        with self.assertRaises(SystemExit):
+            helper.parse_args(["list", "--vw-cd", "INVALID_CODE"])
+
+    def test_explain_requires_stat_id_or_org_tbl(self):
+        args = helper.parse_args(["explain", "--stat-id", "A10120100413104843"])
+        self.assertEqual(args.stat_id, "A10120100413104843")
+        args2 = helper.parse_args(["explain", "--org-id", "101", "--table-id", "DT_1IN0001"])
+        self.assertEqual(args2.org_id, "101")
+        self.assertEqual(args2.table_id, "DT_1IN0001")
+
+    def test_indicator_defaults_service_to_1(self):
+        args = helper.parse_args(["indicator", "--jipyo-id", "160"])
+        self.assertEqual(args.service, "1")
+        self.assertEqual(args.jipyo_id, "160")
+        self.assertEqual(args.page_no, 1)
+        self.assertEqual(args.num_of_rows, 10)
+
+    def test_indicator_invalid_service_rejected(self):
+        with self.assertRaises(SystemExit):
+            helper.parse_args(["indicator", "--jipyo-id", "160", "--service", "9"])
+
 
 class CredentialResolutionTest(unittest.TestCase):
     def test_env_var_takes_precedence(self):
@@ -174,6 +202,40 @@ class UrlBuilderTest(unittest.TestCase):
         self.assertTrue(url.startswith("https://example.com/x?"))
         self.assertIn("a=1", url)
         self.assertIn("b=", url)
+
+    def test_list_params_include_vw_cd_and_parent_id(self):
+        args = helper.parse_args(["list", "--vw-cd", "MT_ZTITLE", "--parent-id", "sub123"])
+        params = helper.build_list_params("KEY", args)
+        self.assertEqual(params["vwCd"], "MT_ZTITLE")
+        self.assertEqual(params["parentId"], "sub123")
+        self.assertEqual(params["method"], "getList")
+
+    def test_explain_params_with_org_and_table(self):
+        args = helper.parse_args(["explain", "--org-id", "101", "--table-id", "DT_1IN0001"])
+        params = helper.build_explain_params("KEY", args)
+        self.assertEqual(params["orgId"], "101")
+        self.assertEqual(params["tblId"], "DT_1IN0001")
+        self.assertEqual(params["metaItm"], "All")
+
+    def test_explain_params_with_stat_id(self):
+        args = helper.parse_args(["explain", "--stat-id", "A10120100413104843"])
+        params = helper.build_explain_params("KEY", args)
+        self.assertEqual(params["statId"], "A10120100413104843")
+        self.assertNotIn("orgId", params)
+
+    def test_explain_without_any_id_exits(self):
+        args = helper.parse_args(["explain"])
+        with self.assertRaises(SystemExit):
+            helper.build_explain_params("KEY", args)
+
+    def test_indicator_params_include_service_and_jipyo_id(self):
+        args = helper.parse_args(["indicator", "--jipyo-id", "160", "--service", "2"])
+        params = helper.build_indicator_params("KEY", args)
+        self.assertEqual(params["jipyoId"], "160")
+        self.assertEqual(params["service"], "2")
+        self.assertEqual(params["serviceDetail"], "pkCalcSource")
+        self.assertEqual(params["pageNo"], "1")
+        self.assertEqual(params["numOfRows"], "10")
 
 
 class JsonHandlingTest(unittest.TestCase):
@@ -339,6 +401,43 @@ class RenderTextTest(unittest.TestCase):
         self.assertIn("35.5", text)
         self.assertIn("%", text)
 
+    def test_list_empty_suggests_parent_id_or_vw_cd(self):
+        text = helper.render_list_text([])
+        self.assertIn("--parent-id", text)
+        self.assertIn("--vw-cd", text)
+
+    def test_list_text_shows_category_entries(self):
+        payload = [
+            {"LIST_ID": "L1", "LIST_NM": "인구/가구", "ORG_ID": "", "TBL_ID": "", "TBL_NM": "", "SEND_DE": ""},
+            {"LIST_ID": "L2", "LIST_NM": "경제/산업", "ORG_ID": "101", "TBL_ID": "DT_X", "TBL_NM": "GDP", "SEND_DE": "20240101"},
+        ]
+        text = helper.render_list_text(payload)
+        self.assertIn("인구/가구", text)
+        self.assertIn("GDP", text)
+        self.assertIn("DT_X", text)
+
+    def test_explain_empty_suggests_search(self):
+        text = helper.render_explain_text([])
+        self.assertIn("search", text)
+
+    def test_explain_text_shows_fields(self):
+        payload = [{"statsNm": "인구총조사", "writingPurps": "인구 파악", "statsPeriod": "5년"}]
+        text = helper.render_explain_text(payload)
+        self.assertIn("인구총조사", text)
+        self.assertIn("인구 파악", text)
+        self.assertIn("조사주기", text)
+
+    def test_indicator_empty_suggests_jipyo_id(self):
+        text = helper.render_indicator_text([])
+        self.assertIn("--jipyo-id", text)
+
+    def test_indicator_text_shows_concept(self):
+        payload = [{"statJipyoId": "160", "statJipyoNm": "인구밀도", "jipyoExplan": "인구밀도 설명", "jipyoExplan1": "1km²당 인구수"}]
+        text = helper.render_indicator_text(payload)
+        self.assertIn("160", text)
+        self.assertIn("인구밀도", text)
+        self.assertIn("1km²당 인구수", text)
+
 
 class DryRunTest(unittest.TestCase):
     def test_dry_run_redacts_api_key_and_does_not_call_network(self):
@@ -367,6 +466,45 @@ class DryRunTest(unittest.TestCase):
         self.assertIn("<DRY-RUN>", out)
         self.assertIn('"via_proxy": false', out)
         self.assertIn("apiKey", out)
+
+    def test_list_dry_run_uses_proxy_and_no_api_key(self):
+        args = helper.parse_args(["list", "--vw-cd", "MT_ZTITLE", "--dry-run", "--json"])
+        with mock.patch.object(helper, "fetch_text") as fetch_mock:
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = helper.run(args)
+        self.assertEqual(rc, 0)
+        fetch_mock.assert_not_called()
+        out = buf.getvalue()
+        self.assertIn('"via_proxy": true', out)
+        self.assertIn("/v1/kosis/list", out)
+        self.assertIn("statisticsList.do", out)
+
+    def test_explain_dry_run_uses_proxy(self):
+        args = helper.parse_args(["explain", "--org-id", "101", "--table-id", "DT_1IN0001", "--dry-run", "--json"])
+        with mock.patch.object(helper, "fetch_text") as fetch_mock:
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = helper.run(args)
+        self.assertEqual(rc, 0)
+        fetch_mock.assert_not_called()
+        out = buf.getvalue()
+        self.assertIn('"via_proxy": true', out)
+        self.assertIn("/v1/kosis/explain", out)
+        self.assertIn("statisticsExplData.do", out)
+
+    def test_indicator_dry_run_uses_proxy(self):
+        args = helper.parse_args(["indicator", "--jipyo-id", "160", "--dry-run", "--json"])
+        with mock.patch.object(helper, "fetch_text") as fetch_mock:
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = helper.run(args)
+        self.assertEqual(rc, 0)
+        fetch_mock.assert_not_called()
+        out = buf.getvalue()
+        self.assertIn('"via_proxy": true', out)
+        self.assertIn("/v1/kosis/indicator", out)
+        self.assertIn("pkNumberService.do", out)
 
 
 class RunIntegrationTest(unittest.TestCase):

--- a/packages/k-skill-proxy/src/server.js
+++ b/packages/k-skill-proxy/src/server.js
@@ -820,6 +820,79 @@ function normalizeKosisDataQuery(query) {
   return normalized;
 }
 
+function normalizeKosisListQuery(query) {
+  const vwCd = trimOrNull(query.vwCd ?? query.vw_cd);
+  if (!vwCd) {
+    throw new Error("Provide vwCd (service view code).");
+  }
+  return {
+    method: "getList",
+    format: "json",
+    jsonVD: "Y",
+    vwCd,
+    parentId: trimOrNull(query.parentId ?? query.parent_id) || ""
+  };
+}
+
+function normalizeKosisExplainQuery(query) {
+  const statId = trimOrNull(query.statId ?? query.stat_id);
+  const orgId = trimOrNull(query.orgId ?? query.org_id);
+  const tblId = trimOrNull(query.tblId ?? query.table_id ?? query.tbl_id);
+  const metaItm = trimOrNull(query.metaItm ?? query.meta_itm) || "All";
+
+  if (!statId && !(orgId && tblId)) {
+    throw new Error("Provide statId or both orgId and tblId.");
+  }
+
+  const normalized = {
+    method: "getList",
+    format: "json",
+    jsonVD: "Y",
+    metaItm
+  };
+  if (statId) {
+    normalized.statId = statId;
+  } else {
+    normalized.orgId = orgId;
+    normalized.tblId = tblId;
+  }
+  return normalized;
+}
+
+function normalizeKosisIndicatorQuery(query) {
+  const service = trimOrNull(query.service) || "1";
+  if (!["1", "2", "3"].includes(service)) {
+    throw new Error("service must be 1, 2, or 3.");
+  }
+  const jipyoId = trimOrNull(query.jipyoId ?? query.jipyo_id);
+  if (!jipyoId) {
+    throw new Error("Provide jipyoId.");
+  }
+
+  const serviceDetailMap = { "1": "pkNotion", "2": "pkCalcSource", "3": "pkAll" };
+
+  return {
+    method: "getList",
+    format: "json",
+    jsonVD: "Y",
+    service,
+    serviceDetail: serviceDetailMap[service],
+    jipyoId,
+    pageNo: String(parseBoundedPositiveInteger(query.pageNo ?? query.page_no ?? query.page, {
+      defaultValue: 1,
+      min: 1,
+      max: 1000000,
+      label: "pageNo"
+    })),
+    numOfRows: String(parseBoundedPositiveInteger(query.numOfRows ?? query.num_of_rows ?? query.limit, {
+      defaultValue: 10,
+      min: 1,
+      max: 5000,
+      label: "numOfRows"
+    }))
+  };
+}
+
 function normalizeKakaoLocalGeocodeQuery(query) {
   const q = trimOrNull(query.q ?? query.query);
   if (!q) {
@@ -1503,7 +1576,10 @@ async function proxyKosisRequest({
   const paths = {
     search: "statisticsSearch.do",
     meta: "statisticsData.do",
-    data: "Param/statisticsParameterData.do"
+    data: "Param/statisticsParameterData.do",
+    list: "statisticsList.do",
+    explain: "statisticsExplData.do",
+    indicator: "pkNumberService.do"
   };
   const path = paths[operation];
 
@@ -2376,6 +2452,30 @@ function buildServer({ env = process.env, provider = null, now = () => new Date(
     operation: "data",
     normalize: normalizeKosisDataQuery,
     cacheRoute: "kosis-data",
+    request,
+    reply
+  }));
+
+  app.get("/v1/kosis/list", async (request, reply) => handleKosisRoute({
+    operation: "list",
+    normalize: normalizeKosisListQuery,
+    cacheRoute: "kosis-list",
+    request,
+    reply
+  }));
+
+  app.get("/v1/kosis/explain", async (request, reply) => handleKosisRoute({
+    operation: "explain",
+    normalize: normalizeKosisExplainQuery,
+    cacheRoute: "kosis-explain",
+    request,
+    reply
+  }));
+
+  app.get("/v1/kosis/indicator", async (request, reply) => handleKosisRoute({
+    operation: "indicator",
+    normalize: normalizeKosisIndicatorQuery,
+    cacheRoute: "kosis-indicator",
     request,
     reply
   }));


### PR DESCRIPTION
## Summary

KOSIS 공식 Open API가 총 7종인데 기존 스킬은 4종만 커버하고 있었습니다. 누락된 3개 endpoint를 추가합니다.


### 새로 추가된 서브커맨드

| # | 서브커맨드 | Endpoint | 용도 |
|---|-----------|----------|------|
| 5 | `list` | `statisticsList.do` | 통계목록 카테고리 트리 탐색 (주제별/기관별/국제통계/북한통계 등) |
| 6 | `explain` | `statisticsExplData.do` | 통계설명 (조사목적·주기·대상·법적근거·공표방법 등 27개 항목) |
| 7 | `indicator` | `pkNumberService.do` | 통계주요지표 (1,473개 핵심 지표의 개념·산정방법·출처) |







### 주의사항

- proxy 서버에 새 라우트(`/v1/kosis/list`, `/v1/kosis/explain`, `/v1/kosis/indicator`)가 배포되어야 live 호출이 가능합니다
- 기존 4개 서브커맨드(search/meta/data/bigdata)에는 영향 없음