### PR TITLE
feat: add k-skill-proxy-setup skill for self-hosting

### DIFF
--- a/k-skill-proxy-setup/SKILL.md
+++ b/k-skill-proxy-setup/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: k-skill-proxy-setup
+description: k-skill의 proxy-routed 스킬(날씨, 미세먼지, KOSIS, 부동산, 주식, 급식, 도서관 등)이 필요로 하는 k-skill-proxy 서버를 로컬에 띄우고 API 키를 설정하는 방법을 안내한다. Use when the user wants to self-host k-skill-proxy instead of using a hosted instance.
+license: MIT
+metadata:
+  category: setup
+  locale: ko-KR
+  phase: v1
+---
+
+# k-skill Proxy Setup
+
+## What this skill does
+
+k-skill의 많은 스킬이 **k-skill-proxy**라는 중계 서버를 통해 한국 공공/데이터 API를 호출한다. 이 proxy는 사용자의 API 키를 서버 쪽에서 주입하여, 매 스킬 호출마다 키를 노출하지 않는다.
+
+이 스킬은 **사용자가 자체 proxy를 로컬에 띄우는 방법**을 안내한다.
+
+## When to use
+
+- k-skill 설치 후 proxy가 필요한 스킬을 사용하려 하는데 기존 hosted proxy를 쓰지 않을 때
+- 자체 서버/로컬에서 proxy를 운영하려 할 때
+- API 키 발급부터 proxy 기동까지 전체 흐름이 필요할 때
+
+## When not to use
+
+- 이미 `KSKILL_PROXY_BASE_URL`이 설정되어 있고 정상 동작 중일 때
+- proxy가 필요 없는 스킬(SRT/KTX 예매, 카카오톡 검색, HWP 등)만 사용할 때
+
+## Prerequisites
+
+- **Docker** (권장) — [설치 가이드](https://docs.docker.com/get-docker/)
+- 또는 **Node.js 18+** (Docker 없이 직접 실행할 때)
+- **git**
+
+## Architecture
+
+```
+에이전트 / 코딩 에이전트 (Claude Code, Codex, OpenCode 등)
+    ↓ KSKILL_PROXY_BASE_URL=http://localhost:8080
+k-skill-proxy (localhost:8080, Docker container)
+    ↓ API 키를 주입하여 호출
+한국 공공데이터 API (data.go.kr, kosis.kr, kma.go.kr, ...)
+```
+
+## Workflow
+
+### 1. Clone the repo
+
+```bash
+git clone https://github.com/NomaDamas/k-skill.git
+cd k-skill
+```
+
+### 2. Get API keys
+
+proxy가 주입할 API 키를 발급받는다. **전부 무료**이며, 어떤 스킬을 쓸지에 따라 필요한 키가 다르다.
+
+필수/선택별 발급 안내는 [`references/api-keys-guide.md`](references/api-keys-guide.md)를 참고한다.
+
+최소 구성 (날씨, 미세먼지, KOSIS 통계, 부동산, 주식, 급식, 도서관 등 대부분 커버):
+
+| 키 | 발급처 | 용도 |
+| --- | --- | --- |
+| `DATA_GO_KR_API_KEY` | [공공데이터포털](https://www.data.go.kr) | 부동산, 급식, 의약품, 식품, 국민연금, 금융위, 나라장터, K-Startup 등 |
+| `KOSIS_API_KEY` | [KOSIS 공유서비스](https://kosis.kr/openapi/) | 한국 공식 통계 조회 |
+| `KMA_OPEN_API_KEY` | [기상청 단기예보](https://www.data.go.kr/data/AWS_T_AASDIA_M) | 한국 날씨 |
+| `AIR_KOREA_OPEN_API_KEY` | [에어코리아 대기오염정보](https://www.data.go.kr/data/15073861/openapi.do) | 미세먼지 |
+| `SEOUL_OPEN_API_KEY` | [서울 열린데이터광장](https://data.seoul.go.kr/) | 지하철 도착정보, 실시간 혼잡도, 따릉이 |
+| `KAKAO_REST_API_KEY` | [Kakao Developers](https://developers.kakao.com/) | 카카오맵 장소/길찾기, 카카오 로컬 |
+| `OPINET_API_KEY` | [오피넷](https://www.opinet.co.kr/) | 주유소 가격 |
+| `HRFCO_OPEN_API_KEY` | [한국하천정보](https://www.data.go.kr/data/15096280/openapi.do) | 한강 수위 |
+
+선택 (특정 스킬만 필요할 때):
+
+| 키 | 발급처 | 용도 |
+| --- | --- | --- |
+| `KRX_API_KEY` | [KRX 정보데이터시스템](https://data.krx.co.kr/) | 한국 주식 |
+| `DATA4LIBRARY_AUTH_KEY` | [도서관 정보나루](https://data4library.kr/) | 도서관 도서 검색 |
+| `KEDU_INFO_KEY` | [교육행정정보시스템(NEIS)](https://open.neis.go.kr/) | 학교 급식 식단 |
+| `FOODSAFETYKOREA_API_KEY` | [식품안전정보포털](https://www.foodsafetykorea.go.kr/) | 식품 안전 (선택, DATA_GO_KR_API_KEY만으로도 기본 동작) |
+| `NAVER_SEARCH_CLIENT_ID` + `NAVER_SEARCH_CLIENT_SECRET` | [Naver Developers](https://developers.naver.com/) | 네이버 쇼핑, 뉴스 검색 |
+| `LAW_OC` | [국가법령정보센터](https://open.law.go.kr) | 한국 법령 검색 |
+
+### 3. Create secrets file
+
+```bash
+cat > ~/.config/k-skill/proxy-secrets.env <<'EOF'
+# --- 필수 ---
+DATA_GO_KR_API_KEY=여기에_발급받은_키
+KOSIS_API_KEY=여기에_발급받은_키
+KMA_OPEN_API_KEY=여기에_발급받은_키
+AIR_KOREA_OPEN_API_KEY=여기에_발급받은_키
+SEOUL_OPEN_API_KEY=여기에_발급받은_키
+KAKAO_REST_API_KEY=여기에_발급받은_키
+OPINET_API_KEY=여기에_발급받은_키
+HRFCO_OPEN_API_KEY=여기에_발급받은_키
+
+# --- 선택 ---
+KRX_API_KEY=
+DATA4LIBRARY_AUTH_KEY=
+KEDU_INFO_KEY=
+FOODSAFETYKOREA_API_KEY=
+NAVER_SEARCH_CLIENT_ID=
+NAVER_SEARCH_CLIENT_SECRET=
+LAW_OC=
+
+# --- 런타임 ---
+KSKILL_PROXY_HOST=0.0.0.0
+KSKILL_PROXY_PORT=8080
+EOF
+chmod 0600 ~/.config/k-skill/proxy-secrets.env
+```
+
+### 4. Start the proxy
+
+#### Option A: Docker (권장)
+
+```bash
+cd /path/to/k-skill
+
+# 이미지 빌드
+docker build -f packages/k-skill-proxy/Dockerfile -t k-skill-proxy .
+
+# 컨테이너 실행
+docker run -d \
+  --name k-skill-proxy \
+  --restart unless-stopped \
+  --env-file ~/.config/k-skill/proxy-secrets.env \
+  -p 8080:8080 \
+  k-skill-proxy
+```
+
+#### Option B: Node.js 직접 실행
+
+```bash
+cd /path/to/k-skill/packages/k-skill-proxy
+npm install --omit=dev
+# 환경변수를 로드한 후 실행
+set -a; source ~/.config/k-skill/proxy-secrets.env; set +a
+node src/server.js
+```
+
+### 5. Verify
+
+```bash
+# 헬스체크
+curl http://localhost:8080/health
+```
+
+정상 응답 예:
+
+```json
+{
+  "ok": true,
+  "service": "k-skill-proxy",
+  "upstreams": {
+    "kosisConfigured": true,
+    "kakaoLocalConfigured": true,
+    ...
+  }
+}
+```
+
+`*Configured`가 `false`인 항목은 해당 API 키가 설정되지 않은 것이다. 필요한 스킬의 키만 채우면 된다.
+
+### 6. Point your skills at the proxy
+
+```bash
+# secrets.env에 proxy URL 등록
+echo 'KSKILL_PROXY_BASE_URL=http://localhost:8080' >> ~/.config/k-skill/secrets.env
+```
+
+이제 모든 proxy-routed 스킬이 `http://localhost:8080`을 기본 proxy로 사용한다.
+
+## Done when
+
+- `curl http://localhost:8080/health` 가 `ok: true` 를 반환한다
+- 사용하려는 스킬의 upstream 키가 `*Configured: true` 로 나타난다
+- `~/.config/k-skill/secrets.env`에 `KSKILL_PROXY_BASE_URL=http://localhost:8080` 이 설정되어 있다
+
+## Updating the proxy
+
+```bash
+cd /path/to/k-skill
+git pull
+docker build -f packages/k-skill-proxy/Dockerfile -t k-skill-proxy .
+docker rm -f k-skill-proxy
+docker run -d \
+  --name k-skill-proxy \
+  --restart unless-stopped \
+  --env-file ~/.config/k-skill/proxy-secrets.env \
+  -p 8080:8080 \
+  k-skill-proxy
+```
+
+## Failure modes
+
+- **포트 충돌** (`8080 already in use`): `KSKILL_PROXY_PORT=9090` 등으로 변경하고 `KSKILL_PROXY_BASE_URL`도 같이 바꾼다
+- **API 키 미설정**: `/health` 응답의 `*Configured`가 `false`. 발급받은 키를 `proxy-secrets.env`에 추가하고 컨테이너를 재시작한다
+- **Docker 미설치**: Docker를 설치하거나 Node.js 직접 실행을 사용한다
+- **공공데이터포털 키 인코딩**: 공공데이터포털 키는 percent-encoding된 형태로 복사된다. 그대로 넣어도 된다
+- **KOSIS 키 만료**: KOSIS 키는 활용신청 시점부터 유효하다. KOSIS 웹에서 활용신청 상태를 확인한다
+
+## Safety notes
+
+- `proxy-secrets.env` 파일 퍼미션은 `0600`으로 유지한다
+- API 키를 git에 커밋하지 않는다
+- proxy를 외부에 공개할 때는 방화벽/인증을 추가한다 (기본은 auth 없음)
+- 공공데이터포털 키는 일일 호출 한도가 있다. proxy의 rate limit (`KSKILL_PROXY_RATE_LIMIT_MAX`)으로 조절한다

--- a/k-skill-proxy-setup/references/api-keys-guide.md
+++ b/k-skill-proxy-setup/references/api-keys-guide.md
@@ -1,0 +1,131 @@
+# API Keys 발급 가이드
+
+k-skill-proxy가 주입할 수 있는 모든 API 키의 발급처와 방법을 정리한다.
+
+전부 **무료**다. 발급받은 키를 `proxy-secrets.env` 파일에 넣는다.
+
+## 필수 키 (대부분의 스킬을 커버)
+
+### DATA_GO_KR_API_KEY — 공공데이터포털
+
+- **발급 URL**: https://www.data.go.kr → 회원가입 → 마이페이지 → "인증키 신청"
+- **용도**: 부동산 실거래가, 학교 급식 식단, 의약품 안전, 식품 안전, 국민연금 사업장, 금융위 기업정보, 나라장터 발주/제재, K-Startup, 생활쓰레기 배출정보 등
+- **특이사항**: 키가 percent-encoding 되어 복사됨. 그대로 넣어도 된다
+- **복수 서비스**: 이 키 하나로 공공데이터포털의 모든 open API에 접근 가능
+
+### KOSIS_API_KEY — 국가통계포털
+
+- **발급 URL**: https://kosis.kr/openapi/ → 회원가입 → "활용신청" (상시신청)
+- **용도**: 한국 공식 통계 (인구, 물가, 고용 등) 검색/조회
+- **특이사항**: 활용신청 후 승인까지 최대 1~2일 소요 가능
+
+### KMA_OPEN_API_KEY — 기상청
+
+- **발급 URL**: https://www.data.go.kr/data/15084084/openapi.do (기상청 단기예보 조회서비스) → "활용신청"
+- **용도**: 한국 날씨 조회
+
+### AIR_KOREA_OPEN_API_KEY — 에어코리아
+
+- **발급 URL**: https://www.data.go.kr/data/15073861/openapi.do (대기오염정보 조회 서비스) → "활용신청"
+- **용도**: 미세먼지(PM10/PM2.5) 조회
+
+### SEOUL_OPEN_API_KEY — 서울 열린데이터광장
+
+- **발급 URL**: https://data.seoul.go.kr/ → 회원가입 → "인증키 신청"
+- **용도**: 서울 지하철 도착정보, 실시간 혼잡도, 따릉이 대여소
+
+### KAKAO_REST_API_KEY — Kakao Developers
+
+- **발급 URL**: https://developers.kakao.com/ → 로그인 → "내 애플리케이션" → 앱 생성 → REST API 키 발급
+- **용도**: 카카오맵 장소 검색, 주소↔좌표 변환, 자동차 길찾이, 근처 술집
+- **특이사항**: 발급 후 "플랫폼 설정"에서 Web 플랫폼을 추가하고 사이트 도메인을 등록해야 할 수 있음
+
+### OPINET_API_KEY — 오피넷
+
+- **발급 URL**: https://www.opinet.co.kr/ → "오피넷 오픈API" 하단 → 신청서 다운로드/이메일 신청
+- **용도**: 근처 가장 싼 주유소 조회
+- **특이사항**: 이메일 심사 후 발급 (1~3일)
+
+### HRFCO_OPEN_API_KEY — 한국하천정보
+
+- **발급 URL**: https://www.data.go.kr/data/15096280/openapi.do (하천수위수질개방서비스) → "활용신청"
+- **용도**: 한강 수위 정보
+
+---
+
+## 선택 키 (특정 스킬만 필요)
+
+### KRX_API_KEY — 한국거래소
+
+- **발급 URL**: https://data.krx.co.kr/ → "회원가입" → 마이페이지 → "OPEN API 신청"
+- **용도**: 한국 주식 정보 조회 (KRX 상장 종목 검색, 시세)
+- **특이사항**: 웹에서만 신청 가능, 이메일 승인 필요
+
+### DATA4LIBRARY_AUTH_KEY — 도서관 정보나루
+
+- **발급 URL**: https://data4library.kr/ → 회원가입 → "API 활용 신청"
+- **용도**: 도서관 도서 검색, 상세 조회, 소장 도서관 확인
+
+### KEDU_INFO_KEY — 교육행정정보시스템 (NEIS)
+
+- **발급 URL**: https://open.neis.go.kr/ → 회원가입 → "API 활용신청"
+- **용도**: 학교 검색, 학교 급식 식단 조회
+
+### FOODSAFETYKOREA_API_KEY — 식품안전정보포털
+
+- **발급 URL**: https://www.foodsafetykorea.go.kr/api/openApiInfo.do → "API 신청"
+- **용도**: 식품 안전 (식약처 부적합 식품, 회수 정보 보충)
+- **특이사항**: `DATA_GO_KR_API_KEY`만으로도 식품 안전 기본 기능이 동작함. 이 키는 추가 데이터용
+
+### NAVER_SEARCH_CLIENT_ID + NAVER_SEARCH_CLIENT_SECRET — Naver Developers
+
+- **발급 URL**: https://developers.naver.com/ → "Application 등록" → "검색" API 선택
+- **용도**: 네이버 쇼핑 검색, 네이버 뉴스 검색
+- **특이사항**: Client ID와 Client Secret 두 개가 한 쌍으로 필요
+
+### LAW_OC — 국가법령정보센터
+
+- **발급 URL**: https://open.law.go.kr → 회원가입 → "OPEN API 안내" → 인증키 신청
+- **용도**: 한국 법령/조문/판례/유권해석 검색
+- **특이사항**: `OC` 파라미터값만 사용. 이메일 주소 기반 발급
+
+---
+
+## 런타임 환경변수 (선택)
+
+proxy 동작을 미세 조정할 때 설정한다. 기본값으로 충분하다.
+
+| 변수 | 기본값 | 설명 |
+| --- | --- | --- |
+| `KSKILL_PROXY_HOST` | `0.0.0.0` | 바인드 주소 |
+| `KSKILL_PROXY_PORT` | `8080` | 포트 (`PORT` 환경변수로도 덮어쓰기 가능) |
+| `KSKILL_PROXY_CACHE_TTL_MS` | `300000` (5분) | 응답 캐시 유지 시간 |
+| `KSKILL_PROXY_RATE_LIMIT_WINDOW_MS` | `60000` (1분) | rate limit 윈도우 |
+| `KSKILL_PROXY_RATE_LIMIT_MAX` | `60` | 분당 최대 요청 수 |
+
+## proxy-secrets.env 전체 템플릿
+
+```bash
+# === 필수 (대부분의 스킬) ===
+DATA_GO_KR_API_KEY=발급받은키
+KOSIS_API_KEY=발급받은키
+KMA_OPEN_API_KEY=발급받은키
+AIR_KOREA_OPEN_API_KEY=발급받은키
+SEOUL_OPEN_API_KEY=발급받은키
+KAKAO_REST_API_KEY=발급받은키
+OPINET_API_KEY=발급받은키
+HRFCO_OPEN_API_KEY=발급받은키
+
+# === 선택 (특정 스킬) ===
+KRX_API_KEY=
+DATA4LIBRARY_AUTH_KEY=
+KEDU_INFO_KEY=
+FOODSAFETYKOREA_API_KEY=
+NAVER_CLIENT_ID=
+NAVER_CLIENT_SECRET=
+LAW_OC=
+
+# === 런타임 (기본값으로 충분) ===
+KSKILL_PROXY_HOST=0.0.0.0
+KSKILL_PROXY_PORT=8080
+```


### PR DESCRIPTION
## Summary

기존에는 gpu01에 떠 있는 hosted proxy(`k-skill-proxy.nomadamas.org`)를 기본으로 사용하는 구조였습니다. 이를 탈피하고, **사용자가 자체 proxy를 로컬에 띄우는 방법**을 스킬로 정리했습니다.

### 새 스킬: `k-skill-proxy-setup`

| 섹션 | 내용 |
|------|------|
| Architecture | agent → local proxy → upstream API 구조도 |
| Docker quick-start | `docker build` + `docker run` 한 번에 실행 |
| Node.js fallback | Docker 없이 `node src/server.js` 직접 실행 |
| API keys guide | 16개 키 전체 발급처 URL + 용도 + 특이사항 |
| secrets.env template | 필수/선택/런타임 분리된 전체 템플릿 |
| Health check | `/health` 응답 검증 방법 |
| Wiring | `KSKILL_PROXY_BASE_URL=http://localhost:8080` 등록 |
| Updating | git pull + rebuild 절차 |
| Troubleshooting | 포트 충돌, 키 미설정, Docker 미설치 등 |

### 구조

```
k-skill-proxy-setup/
├── SKILL.md                        (210 lines)
└── references/
    └── api-keys-guide.md           (131 lines)
```

### 사용자 관점 흐름

1. `git clone k-skill`
2. API 키 발급 (references/api-keys-guide.md 참조)
3. `proxy-secrets.env` 작성
4. `docker build` + `docker run`
5. `curl localhost:8080/health` 확인
6. `KSKILL_PROXY_BASE_URL=http://localhost:8080` 등록
7. 끝 — 모든 proxy-routed 스킬이 동작