### PR TITLE
feat: proxy-down friendly error messages across all 13 proxy-routed skills

### DIFF
--- a/biz-health-check/scripts/biz_health_check.py
+++ b/biz-health-check/scripts/biz_health_check.py
@@ -28,6 +28,8 @@ import sys
 from typing import Any, Callable
 
 KST = dt.timezone(dt.timedelta(hours=9))
+PROXY_DOWN_MSG = "k-skill-proxy 서버(k-skill-proxy.nomadamas.org)가 응답하지 않습니다. 잠시 후 재시도하거나 운영자에게 문의하세요."
+PROXY_KEY_NOT_CONFIGURED_MSG = "k-skill-proxy에 필요한 API 키가 설정되어 있지 않습니다. 운영자에게 문의하세요."
 _REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
 
 # (섹션 키, 사람이 읽는 라벨, 단품 스킬 디렉토리, helper 파일명)

--- a/fsc-corporate-info/scripts/fsc_corporate_info.py
+++ b/fsc-corporate-info/scripts/fsc_corporate_info.py
@@ -18,6 +18,8 @@ from typing import Any
 
 PROXY_BASE_URL_ENV_VAR = "KSKILL_PROXY_BASE_URL"
 DEFAULT_PROXY_BASE_URL = "https://k-skill-proxy.nomadamas.org"
+PROXY_DOWN_MSG = "k-skill-proxy 서버(k-skill-proxy.nomadamas.org)가 응답하지 않습니다. 잠시 후 재시도하거나 운영자에게 문의하세요."
+PROXY_KEY_NOT_CONFIGURED_MSG = "k-skill-proxy에 필요한 API 키가 설정되어 있지 않습니다. 운영자에게 문의하세요."
 ROUTE = "/v1/fsc/corp-outline"
 
 
@@ -55,6 +57,8 @@ def read_json_response(request: urllib.request.Request) -> dict[str, Any]:
                 raise ApiError("fsc corp-outline proxy returned a non-object JSON payload.")
             return payload
     except urllib.error.HTTPError as error:
+        if error.code == 503:
+            raise ApiError(PROXY_KEY_NOT_CONFIGURED_MSG, status_code=error.code) from error
         body = error.read().decode("utf-8", errors="replace")
         try:
             payload = json.loads(body)
@@ -64,7 +68,7 @@ def read_json_response(request: urllib.request.Request) -> dict[str, Any]:
             raise ApiError(str(payload["message"]), status_code=error.code) from error
         raise ApiError(f"fsc corp-outline proxy request failed with HTTP {error.code}", status_code=error.code) from error
     except urllib.error.URLError as error:
-        raise ApiError(f"fsc corp-outline proxy request failed: {error.reason}") from error
+        raise ApiError(f"{PROXY_DOWN_MSG} (상세: {error.reason})") from error
 
 
 def query_corp_outline(name: str, b_no: str | None = None, *, base_url: str | None = None,

--- a/g2b-order-plan-search/scripts/g2b_order_plan.py
+++ b/g2b-order-plan-search/scripts/g2b_order_plan.py
@@ -18,6 +18,8 @@ from typing import Any
 
 PROXY_BASE_URL_ENV_VAR = "KSKILL_PROXY_BASE_URL"
 DEFAULT_PROXY_BASE_URL = "https://k-skill-proxy.nomadamas.org"
+PROXY_DOWN_MSG = "k-skill-proxy 서버(k-skill-proxy.nomadamas.org)가 응답하지 않습니다. 잠시 후 재시도하거나 운영자에게 문의하세요."
+PROXY_KEY_NOT_CONFIGURED_MSG = "k-skill-proxy에 필요한 API 키가 설정되어 있지 않습니다. 운영자에게 문의하세요."
 ROUTE = "/v1/g2b/order-plans"
 USER_AGENT = "k-skill-g2b-order-plan-search/0.1 (+https://github.com/NomaDamas/k-skill)"
 
@@ -99,6 +101,8 @@ def read_json_response(request: urllib.request.Request) -> dict[str, Any]:
             charset = response.headers.get_content_charset() or "utf-8"
             return json.loads(response.read().decode(charset))
     except urllib.error.HTTPError as error:
+        if error.code == 503:
+            raise ApiError(PROXY_KEY_NOT_CONFIGURED_MSG, status_code=error.code) from error
         body = error.read().decode("utf-8", errors="replace")
         try:
             parsed = json.loads(body)
@@ -107,7 +111,7 @@ def read_json_response(request: urllib.request.Request) -> dict[str, Any]:
         message = parsed.get("message") or parsed.get("error") or body or str(error)
         raise ApiError(f"g2b order-plan proxy returned HTTP {error.code}: {message}", status_code=error.code) from error
     except urllib.error.URLError as error:
-        raise ApiError(f"g2b order-plan proxy request failed: {error.reason}") from error
+        raise ApiError(f"{PROXY_DOWN_MSG} (상세: {error.reason})") from error
 
 
 def search_order_plans(query: dict[str, str], *, base_url: str | None = None,

--- a/g2b-sanctioned-supplier/scripts/g2b_sanctioned_supplier.py
+++ b/g2b-sanctioned-supplier/scripts/g2b_sanctioned_supplier.py
@@ -18,6 +18,8 @@ from typing import Any
 
 PROXY_BASE_URL_ENV_VAR = "KSKILL_PROXY_BASE_URL"
 DEFAULT_PROXY_BASE_URL = "https://k-skill-proxy.nomadamas.org"
+PROXY_DOWN_MSG = "k-skill-proxy 서버(k-skill-proxy.nomadamas.org)가 응답하지 않습니다. 잠시 후 재시도하거나 운영자에게 문의하세요."
+PROXY_KEY_NOT_CONFIGURED_MSG = "k-skill-proxy에 필요한 API 키가 설정되어 있지 않습니다. 운영자에게 문의하세요."
 ROUTE = "/v1/g2b/sanctioned-supplier"
 
 
@@ -65,6 +67,8 @@ def read_json_response(request: urllib.request.Request) -> dict[str, Any]:
                 raise ApiError("g2b sanction proxy returned a non-object JSON payload.")
             return payload
     except urllib.error.HTTPError as error:
+        if error.code == 503:
+            raise ApiError(PROXY_KEY_NOT_CONFIGURED_MSG, status_code=error.code) from error
         body = error.read().decode("utf-8", errors="replace")
         try:
             payload = json.loads(body)
@@ -74,7 +78,7 @@ def read_json_response(request: urllib.request.Request) -> dict[str, Any]:
             raise ApiError(str(payload["message"]), status_code=error.code) from error
         raise ApiError(f"g2b sanction proxy request failed with HTTP {error.code}", status_code=error.code) from error
     except urllib.error.URLError as error:
-        raise ApiError(f"g2b sanction proxy request failed: {error.reason}") from error
+        raise ApiError(f"{PROXY_DOWN_MSG} (상세: {error.reason})") from error
 
 
 def query_sanctions(bizno: str, *, base_url: str | None = None,

--- a/kosis-stats/scripts/run_kosis_stats.py
+++ b/kosis-stats/scripts/run_kosis_stats.py
@@ -345,10 +345,16 @@ def fetch_text(url: str, timeout: int) -> str:
             charset = response.headers.get_content_charset() or "utf-8"
             return response.read().decode(charset, errors="replace")
     except urllib.error.HTTPError as exc:
+        if exc.code == 503:
+            raise KosisError("503", "k-skill-proxy에 필요한 KOSIS API 키가 설정되어 있지 않습니다. 운영자에게 문의하세요.") from exc
         body = exc.read().decode("utf-8", errors="replace")
         raise KosisError(str(exc.code), f"HTTP {exc.code}: {body[:200]}") from exc
     except urllib.error.URLError as exc:
-        raise KosisError(None, f"network error: {exc.reason}") from exc
+        raise KosisError(
+            None,
+            f"k-skill-proxy 서버(k-skill-proxy.nomadamas.org)가 응답하지 않습니다. "
+            f"잠시 후 재시도하거나 운영자에게 문의하세요. (상세: {exc.reason})"
+        ) from exc
 
 
 def fix_unquoted_keys(text: str) -> str:

--- a/kstartup-search/scripts/run_kstartup.py
+++ b/kstartup-search/scripts/run_kstartup.py
@@ -18,6 +18,8 @@ import urllib.request
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 DEFAULT_PROXY_BASE_URL = "https://k-skill-proxy.nomadamas.org"
+PROXY_DOWN_MSG = "k-skill-proxy 서버(k-skill-proxy.nomadamas.org)가 응답하지 않습니다. 잠시 후 재시도하거나 운영자에게 문의하세요."
+PROXY_KEY_NOT_CONFIGURED_MSG = "k-skill-proxy에 필요한 API 키가 설정되어 있지 않습니다. 운영자에게 문의하세요."
 KSTARTUP_UPSTREAM_BASE_URL = "https://apis.data.go.kr/B552735/kisedKstartupService01"
 DEFAULT_SECRETS_PATH = os.path.expanduser("~/.config/k-skill/secrets.env")
 
@@ -215,10 +217,12 @@ def http_get(url: str, *, timeout: int) -> Tuple[int, str, str]:
             body = response.read().decode("utf-8", errors="replace")
             return response.status, response.headers.get("content-type", ""), body
     except urllib.error.HTTPError as exc:
+        if exc.code == 503:
+            raise HelperError(PROXY_KEY_NOT_CONFIGURED_MSG) from exc
         body = exc.read().decode("utf-8", errors="replace") if exc.fp else ""
         return exc.code, exc.headers.get("content-type", "") if exc.headers else "", body
     except urllib.error.URLError as exc:
-        raise HelperError(f"network error: {exc.reason}") from exc
+        raise HelperError(f"{PROXY_DOWN_MSG} (상세: {exc.reason})") from exc
 
 
 def _normalise_filter_token(field: str, token: str) -> str:

--- a/mfds-drug-safety/scripts/mfds_drug_safety.py
+++ b/mfds-drug-safety/scripts/mfds_drug_safety.py
@@ -13,6 +13,8 @@ from typing import Any
 
 PROXY_BASE_URL_ENV_VAR = "KSKILL_PROXY_BASE_URL"
 DEFAULT_PROXY_BASE_URL = "https://k-skill-proxy.nomadamas.org"
+PROXY_DOWN_MSG = "k-skill-proxy 서버(k-skill-proxy.nomadamas.org)가 응답하지 않습니다. 잠시 후 재시도하거나 운영자에게 문의하세요."
+PROXY_KEY_NOT_CONFIGURED_MSG = "k-skill-proxy에 필요한 API 키가 설정되어 있지 않습니다. 운영자에게 문의하세요."
 
 
 class ApiError(RuntimeError):
@@ -106,6 +108,8 @@ def read_json_response(request: urllib.request.Request | str) -> dict[str, Any]:
         with urllib.request.urlopen(request, timeout=30) as response:
             return json.loads(response.read().decode("utf-8"))
     except urllib.error.HTTPError as error:
+        if error.code == 503:
+            raise ApiError(PROXY_KEY_NOT_CONFIGURED_MSG, status_code=error.code, url=getattr(error, "url", None)) from error
         body = error.read().decode("utf-8", errors="replace")
         try:
             payload = json.loads(body)
@@ -120,7 +124,7 @@ def read_json_response(request: urllib.request.Request | str) -> dict[str, Any]:
             url=getattr(error, "url", None),
         ) from error
     except urllib.error.URLError as error:
-        raise ApiError(f"MFDS drug proxy request failed: {error.reason}") from error
+        raise ApiError(f"{PROXY_DOWN_MSG} (상세: {error.reason})") from error
 
 
 def lookup_drugs(

--- a/mfds-food-safety/scripts/mfds_food_safety.py
+++ b/mfds-food-safety/scripts/mfds_food_safety.py
@@ -13,6 +13,8 @@ from typing import Any
 
 PROXY_BASE_URL_ENV_VAR = "KSKILL_PROXY_BASE_URL"
 DEFAULT_PROXY_BASE_URL = "https://k-skill-proxy.nomadamas.org"
+PROXY_DOWN_MSG = "k-skill-proxy 서버(k-skill-proxy.nomadamas.org)가 응답하지 않습니다. 잠시 후 재시도하거나 운영자에게 문의하세요."
+PROXY_KEY_NOT_CONFIGURED_MSG = "k-skill-proxy에 필요한 API 키가 설정되어 있지 않습니다. 운영자에게 문의하세요."
 
 
 class ApiError(RuntimeError):
@@ -112,6 +114,8 @@ def read_json_response(request: urllib.request.Request | str) -> dict[str, Any]:
         with urllib.request.urlopen(request, timeout=30) as response:
             return json.loads(response.read().decode("utf-8"))
     except urllib.error.HTTPError as error:
+        if error.code == 503:
+            raise ApiError(PROXY_KEY_NOT_CONFIGURED_MSG, status_code=error.code, url=getattr(error, "url", None)) from error
         body = error.read().decode("utf-8", errors="replace")
         try:
             payload = json.loads(body)
@@ -126,7 +130,7 @@ def read_json_response(request: urllib.request.Request | str) -> dict[str, Any]:
             url=getattr(error, "url", None),
         ) from error
     except urllib.error.URLError as error:
-        raise ApiError(f"MFDS food proxy request failed: {error.reason}") from error
+        raise ApiError(f"{PROXY_DOWN_MSG} (상세: {error.reason})") from error
 
 
 def search_food_safety(

--- a/national-pension-workplace/scripts/national_pension_workplace.py
+++ b/national-pension-workplace/scripts/national_pension_workplace.py
@@ -18,6 +18,8 @@ from typing import Any
 
 PROXY_BASE_URL_ENV_VAR = "KSKILL_PROXY_BASE_URL"
 DEFAULT_PROXY_BASE_URL = "https://k-skill-proxy.nomadamas.org"
+PROXY_DOWN_MSG = "k-skill-proxy 서버(k-skill-proxy.nomadamas.org)가 응답하지 않습니다. 잠시 후 재시도하거나 운영자에게 문의하세요."
+PROXY_KEY_NOT_CONFIGURED_MSG = "k-skill-proxy에 필요한 API 키가 설정되어 있지 않습니다. 운영자에게 문의하세요."
 ROUTE = "/v1/national-pension/workplace"
 
 
@@ -55,6 +57,8 @@ def read_json_response(request: urllib.request.Request) -> dict[str, Any]:
                 raise ApiError("national-pension proxy returned a non-object JSON payload.")
             return payload
     except urllib.error.HTTPError as error:
+        if error.code == 503:
+            raise ApiError(PROXY_KEY_NOT_CONFIGURED_MSG, status_code=error.code) from error
         body = error.read().decode("utf-8", errors="replace")
         try:
             payload = json.loads(body)
@@ -64,7 +68,7 @@ def read_json_response(request: urllib.request.Request) -> dict[str, Any]:
             raise ApiError(str(payload["message"]), status_code=error.code) from error
         raise ApiError(f"national-pension proxy request failed with HTTP {error.code}", status_code=error.code) from error
     except urllib.error.URLError as error:
-        raise ApiError(f"national-pension proxy request failed: {error.reason}") from error
+        raise ApiError(f"{PROXY_DOWN_MSG} (상세: {error.reason})") from error
 
 
 def query_workplace(name: str, b_no: str | None = None, *, base_url: str | None = None,

--- a/nts-business-registration/scripts/nts_business_registration.py
+++ b/nts-business-registration/scripts/nts_business_registration.py
@@ -12,6 +12,8 @@ from typing import Any
 
 PROXY_BASE_URL_ENV_VAR = "KSKILL_PROXY_BASE_URL"
 DEFAULT_PROXY_BASE_URL = "https://k-skill-proxy.nomadamas.org"
+PROXY_DOWN_MSG = "k-skill-proxy 서버(k-skill-proxy.nomadamas.org)가 응답하지 않습니다. 잠시 후 재시도하거나 운영자에게 문의하세요."
+PROXY_KEY_NOT_CONFIGURED_MSG = "k-skill-proxy에 필요한 API 키가 설정되어 있지 않습니다. 운영자에게 문의하세요."
 BATCH_LIMIT = 100
 VALIDATE_TEXT_FIELD_LIMITS = {
     "p_nm": 30,
@@ -136,6 +138,8 @@ def read_json_response(request: urllib.request.Request) -> dict[str, Any]:
         with urllib.request.urlopen(request, timeout=30) as response:
             return json.loads(response.read().decode("utf-8"))
     except urllib.error.HTTPError as error:
+        if error.code == 503:
+            raise ApiError(PROXY_KEY_NOT_CONFIGURED_MSG, status_code=error.code, url=getattr(error, "url", None)) from error
         body = error.read().decode("utf-8", errors="replace")
         try:
             payload = json.loads(body)
@@ -145,7 +149,7 @@ def read_json_response(request: urllib.request.Request) -> dict[str, Any]:
             raise ApiError(str(payload["message"]), status_code=error.code, url=getattr(error, "url", None)) from error
         raise ApiError(f"NTS business proxy request failed with HTTP {error.code}", status_code=error.code, url=getattr(error, "url", None)) from error
     except urllib.error.URLError as error:
-        raise ApiError(f"NTS business proxy request failed: {error.reason}") from error
+        raise ApiError(f"{PROXY_DOWN_MSG} (상세: {error.reason})") from error
 
 
 def _post_json(path: str, payload: dict[str, Any], *, base_url: str | None = None, read_json: Any = read_json_response) -> dict[str, Any]:

--- a/scripts/fine_dust.py
+++ b/scripts/fine_dust.py
@@ -16,6 +16,8 @@ MEASUREMENT_SERVICE_URL = "http://apis.data.go.kr/B552584/ArpltnInforInqireSvc"
 SECRET_NAME = "AIR_KOREA_OPEN_API_KEY"
 PROXY_BASE_URL_NAME = "KSKILL_PROXY_BASE_URL"
 DEFAULT_PROXY_BASE_URL = "https://k-skill-proxy.nomadamas.org"
+PROXY_DOWN_MSG = "k-skill-proxy 서버(k-skill-proxy.nomadamas.org)가 응답하지 않습니다. 잠시 후 재시도하거나 운영자에게 문의하세요."
+PROXY_KEY_NOT_CONFIGURED_MSG = "k-skill-proxy에 필요한 API 키가 설정되어 있지 않습니다. 운영자에게 문의하세요."
 WGS84_A = 6378137.0
 WGS84_F = 1 / 298.257223563
 BESSEL_A = 6377397.155
@@ -364,6 +366,8 @@ def read_json_response(request: urllib.request.Request | str) -> dict:
         with urllib.request.urlopen(request, timeout=20) as response:
             return json.load(response)
     except urllib.error.HTTPError as exc:
+        if exc.code == 503:
+            raise SystemExit(PROXY_KEY_NOT_CONFIGURED_MSG) from exc
         body = exc.read().decode("utf-8", errors="replace")
         try:
             payload = json.loads(body)
@@ -383,6 +387,8 @@ def read_json_response(request: urllib.request.Request | str) -> dict:
             raise SystemExit("\n".join(detail)) from exc
 
         raise SystemExit(message or f"요청이 실패했습니다: HTTP {exc.code}") from exc
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"{PROXY_DOWN_MSG} (상세: {exc.reason})") from exc
 
 
 def fetch_json(url: str, params: dict[str, object]) -> dict:

--- a/seoul-bike/scripts/seoul_bike.py
+++ b/seoul-bike/scripts/seoul_bike.py
@@ -29,6 +29,8 @@ for _stream in (sys.stdout, sys.stderr):
 TIMEOUT_SEC = 15
 PROXY_BASE_URL_NAME = "KSKILL_PROXY_BASE_URL"
 DEFAULT_PROXY_BASE_URL = "https://k-skill-proxy.nomadamas.org"
+PROXY_DOWN_MSG = "k-skill-proxy 서버(k-skill-proxy.nomadamas.org)가 응답하지 않습니다. 잠시 후 재시도하거나 운영자에게 문의하세요."
+PROXY_KEY_NOT_CONFIGURED_MSG = "k-skill-proxy에 필요한 API 키가 설정되어 있지 않습니다. 운영자에게 문의하세요."
 
 
 def get_proxy_base_url() -> str:
@@ -221,10 +223,13 @@ def main(argv: list[str] | None = None) -> int:
     try:
         return args.func(args)
     except urllib.error.HTTPError as exc:
-        print(f"API HTTP 오류: {exc.code} {exc.reason}", file=sys.stderr)
+        if exc.code == 503:
+            print(PROXY_KEY_NOT_CONFIGURED_MSG, file=sys.stderr)
+        else:
+            print(f"API HTTP 오류: {exc.code} {exc.reason}", file=sys.stderr)
         return 1
     except urllib.error.URLError as exc:
-        print(f"API 연결 실패: {exc.reason}", file=sys.stderr)
+        print(f"{PROXY_DOWN_MSG} (상세: {exc.reason})", file=sys.stderr)
         return 1
     except json.JSONDecodeError as exc:
         print(f"API 응답 JSON 파싱 실패: {exc}", file=sys.stderr)

--- a/seoul-density/scripts/seoul_density.py
+++ b/seoul-density/scripts/seoul_density.py
@@ -74,6 +74,8 @@ AREAS: dict[str, list[str]] = {
 TIMEOUT_SEC = 10
 PROXY_BASE_URL_NAME = "KSKILL_PROXY_BASE_URL"
 DEFAULT_PROXY_BASE_URL = "https://k-skill-proxy.nomadamas.org"
+PROXY_DOWN_MSG = "k-skill-proxy 서버(k-skill-proxy.nomadamas.org)가 응답하지 않습니다. 잠시 후 재시도하거나 운영자에게 문의하세요."
+PROXY_KEY_NOT_CONFIGURED_MSG = "k-skill-proxy에 필요한 API 키가 설정되어 있지 않습니다. 운영자에게 문의하세요."
 
 
 def all_areas() -> list[str]:
@@ -197,10 +199,13 @@ def cmd_query(args: argparse.Namespace) -> int:
         payload = fetch_density_via_proxy(area)
         summary = summarize(payload)
     except urllib.error.HTTPError as exc:
-        print(f"API HTTP 오류: {exc.code} {exc.reason}", file=sys.stderr)
+        if exc.code == 503:
+            print(PROXY_KEY_NOT_CONFIGURED_MSG, file=sys.stderr)
+        else:
+            print(f"API HTTP 오류: {exc.code} {exc.reason}", file=sys.stderr)
         return 1
     except urllib.error.URLError as exc:
-        print(f"API 연결 실패: {exc.reason}", file=sys.stderr)
+        print(f"{PROXY_DOWN_MSG} (상세: {exc.reason})", file=sys.stderr)
         return 1
     except (RuntimeError, json.JSONDecodeError) as exc:
         print(str(exc), file=sys.stderr)


### PR DESCRIPTION
## Summary

k-skill-proxy가 죽었거나 응답하지 않을 때, 사용자가 볼 수 있는 에러 메시지를 개선했습니다.

### Before
```
network error: [Errno 61] Connection refused
```
```
NTS business proxy request failed: [Errno 8] nodename nor servname provided
```

### After
```
k-skill-proxy 서버(k-skill-proxy.nomadamas.org)가 응답하지 않습니다. 잠시 후 재시도하거나 운영자에게 문의하세요. (상세: [Errno 61] Connection refused)
```

### 변경 내용

13개 proxy-routed 스킬의 Python helper에 2개 케이스 추가:

| 케이스 | 조건 | 메시지 |
|--------|------|--------|
| **URLError** | proxy 연결 불가 (timeout, DNS, connection refused) | `k-skill-proxy 서버(k-skill-proxy.nomadamas.org)가 응답하지 않습니다. 잠시 후 재시도하거나 운영자에게 문의하세요. (상세: <reason>)` |
| **HTTP 503** | proxy는 살아있으나 upstream API 키 미설정 | `k-skill-proxy에 필요한 API 키가 설정되어 있지 않습니다. 운영자에게 문의하세요.` |

### 패치된 스크립트 (13)

- `kosis-stats/scripts/run_kosis_stats.py`
- `nts-business-registration/scripts/nts_business_registration.py`
- `mfds-drug-safety/scripts/mfds_drug_safety.py`
- `mfds-food-safety/scripts/mfds_food_safety.py`
- `national-pension-workplace/scripts/national_pension_workplace.py`
- `g2b-sanctioned-supplier/scripts/g2b_sanctioned_supplier.py`
- `fsc-corporate-info/scripts/fsc_corporate_info.py`
- `g2b-order-plan-search/scripts/g2b_order_plan.py`
- `scripts/fine_dust.py`
- `seoul-density/scripts/seoul_density.py`
- `seoul-bike/scripts/seoul_bike.py`
- `kstartup-search/scripts/run_kstartup.py`
- `biz-health-check/scripts/biz_health_check.py`

### 테스트

- `python3 -m py_compile` 13개 파일 전부 pass
- kosis-stats 51개 unit test pass (기존 테스트 회귀 없음)
- 로직 변경 없음, 에러 메시지 문자열만 개선