### PR TITLE
docs: align Dolshoi credential runtime contracts

### DIFF
--- a/docs/adding-a-skill.md
+++ b/docs/adding-a-skill.md
@@ -107,6 +107,19 @@ metadata:
 | `metadata.category` | ✅ | `utility` / `transit` / `travel` / `messaging` / `legal` / `setup` 등 |
 | `metadata.locale` | ✅ | `ko-KR` |
 | `metadata.phase` | ✅ | `v1` (안정) / `v1.5` (기능 추가 중) |
+| `broker_allowed_hosts` | ❌ (기본 fail-closed) | cloud-api 가 브로커 경로로 허용할 **exact hostname** 블록 목록 (YAML list). 와일드카드·포트·scheme 불가. 누락 또는 빈 리스트면 이 스킬의 credential은 브로커 capability가 **아예 프로비전되지 않는다** (fail-closed). 값은 cloud-api 호스트에서만 검증되며, agent/model 입력은 신뢰하지 않는다. |
+| `legacy_env_injection` | ❌ (기본 `false`) | `true` 일 때만 평문 `secrets.env` 경로로 폴백한다. 리터럴 `true` 만 opt-in으로 인정한다 (YAML `yes`/`on` 등은 무시). 누락하면 자동으로 불투명 브로커 capability 핸들 경로를 탄다. 평문 주입은 turn 종료 후 즉시 정리되는 audited residual risk이므로 새 스킬은 기본값(`false`)을 그대로 쓴다. |
+
+`broker_allowed_hosts` YAML 형태:
+
+```yaml
+broker_allowed_hosts:
+  - api.example.com
+  - api.partner.com
+legacy_env_injection: false
+```
+
+자격증명 경로와 평문 주입의 신뢰 경계는 [보안/시크릿 정책](security-and-secrets.md) 의 "Credential broker (default path)" 와 "Legacy plaintext env (opt-in)" 섹션을 본다.
 
 ---
 

--- a/docs/adding-a-skill.md
+++ b/docs/adding-a-skill.md
@@ -107,8 +107,7 @@ metadata:
 | `metadata.category` | ✅ | `utility` / `transit` / `travel` / `messaging` / `legal` / `setup` 등 |
 | `metadata.locale` | ✅ | `ko-KR` |
 | `metadata.phase` | ✅ | `v1` (안정) / `v1.5` (기능 추가 중) |
-| `broker_allowed_hosts` | ❌ (기본 fail-closed) | cloud-api 가 브로커 경로로 허용할 **exact hostname** 블록 목록 (YAML list). 와일드카드·포트·scheme 불가. 누락 또는 빈 리스트면 이 스킬의 credential은 브로커 capability가 **아예 프로비전되지 않는다** (fail-closed). 값은 cloud-api 호스트에서만 검증되며, agent/model 입력은 신뢰하지 않는다. |
-| `legacy_env_injection` | ❌ (기본 `false`) | `true` 일 때만 평문 `secrets.env` 경로로 폴백한다. 리터럴 `true` 만 opt-in으로 인정한다 (YAML `yes`/`on` 등은 무시). 누락하면 자동으로 불투명 브로커 capability 핸들 경로를 탄다. 평문 주입은 turn 종료 후 즉시 정리되는 audited residual risk이므로 새 스킬은 기본값(`false`)을 그대로 쓴다. |
+| `broker_allowed_hosts` | ❌ (기본 fail-closed) | Dolshoi Cloud가 **scalar API-key broker**로 허용할 exact hostname 목록 (YAML list). 와일드카드·포트·scheme 불가. 누락 또는 빈 리스트면 이 스킬의 API-key broker capability가 프로비전되지 않는다. 값은 cloud-api 호스트에서만 검증하며 agent/model 입력은 신뢰하지 않는다. Login credential과 note에는 이 경로를 쓰지 않는다. |
 
 `broker_allowed_hosts` YAML 형태:
 
@@ -116,10 +115,11 @@ metadata:
 broker_allowed_hosts:
   - api.example.com
   - api.partner.com
-legacy_env_injection: false
 ```
 
-자격증명 경로와 평문 주입의 신뢰 경계는 [보안/시크릿 정책](security-and-secrets.md) 의 "Credential broker (default path)" 와 "Legacy plaintext env (opt-in)" 섹션을 본다.
+Dolshoi Cloud에는 스킬 파일이나 환경변수로 credential 평문을 자동 주입하는 경로가 없다. API key를 값 비노출 상태로 HTTPS 요청에 쓰려면 위 scalar broker를 사용한다. Login 등 구조화 credential은 `vault-run` Credential Actions를 사용하고, 서비스별 blind action이 있으면 값을 보지 않는 그 action을 우선한다. 직접 실행에 값이 꼭 필요할 때만 audited `vault-run <capability_id> get`으로 현재 프로세스에 가져오며, 채팅·로그·파일에 남기지 않는다.
+
+자격증명 경로별 신뢰 경계와 generic/local runtime의 환경변수·host vault·`secrets.env` fallback은 [보안/시크릿 정책](security-and-secrets.md)을 본다.
 
 ---
 
@@ -237,12 +237,14 @@ npm run ci
 
 ## 시크릿이 필요한 스킬
 
-인증이 필요한 스킬은 아래 우선순위로 credential을 확보한다.
+Dolshoi Cloud에서는 scalar API-key broker 또는 Credential Actions를 사용한다. 저장된 credential이 없으면 `vault-run credential-request request <항목이름> <login|api_key|note>`로 입력 폼을 띄우고, 값을 채팅으로 받지 않는다. Cloud runtime은 `secrets.env`를 읽어 agent 환경에 평문 주입하지 않는다.
 
-1. 이미 환경변수에 있으면 → 그대로 사용
-2. 에이전트 vault(1Password, Bitwarden, macOS Keychain) → 주입
-3. 개인 dotenv 파일 → 파일에서 읽기
-4. 아무것도 없으면 → 사용자에게 물어보고 개인 dotenv 파일에 저장
+Cloud가 아닌 generic/local/self-hosted runtime은 아래 우선순위로 credential을 확보한다.
+
+1. 이미 환경변수에 있으면 그대로 사용
+2. host의 secret vault(1Password CLI, Bitwarden CLI, macOS Keychain 등)에서 현재 명령에만 주입
+3. 개인 dotenv 파일(예: `~/.config/k-skill/secrets.env`, `0600`)에서 읽기
+4. 아무것도 없으면 사용자에게 로컬 secret store 설정을 요청하고 멈추기
 
 시크릿 변수 이름 규칙: `KSKILL_<서비스명>_<항목>` (예: `KSKILL_SRT_ID`)
 

--- a/docs/security-and-secrets.md
+++ b/docs/security-and-secrets.md
@@ -1,17 +1,31 @@
 # Security And Secrets
 
-`k-skill`은 **필요한 환경변수 이름만 선언**하고, 그 값을 어떻게 공급하느냐는 에이전트의 자유에 맡긴다.
+`k-skill`은 필요한 credential metadata와 환경변수 이름만 선언한다. 값을 공급하는 경로와 신뢰 경계는 runtime별로 다르다.
 
-## Credential broker (default path)
+## Dolshoi Cloud credential paths
 
-Dolshoi Cloud(`apps/cloud-api`)에서 스킬이 실행될 때, 기본적으로 credential 평문 값은 에이전트에게 **전달되지 않는다**. 대신 cloud-api 가 값을 복호화해 in-process 에 보관하고, 에이전트에게는 불투명(opaque) capability 핸들만 넘긴다.
+Dolshoi Cloud(`apps/cloud-api`)는 `secrets.env`나 다른 파일의 credential 평문을 agent 환경에 자동 주입하지 않는다. Cloud skill은 아래 경로 중 목적에 맞는 하나를 사용한다.
+
+### Scalar API-key broker (blind)
+
+Scalar broker는 API key 하나를 허용된 HTTPS 요청의 `Authorization: Bearer` 헤더에 서버 사이드로 주입한다. cloud-api가 값을 복호화해 in-process에 보관하고, 에이전트에게는 불투명(opaque) capability 핸들만 넘긴다.
 
 - 핸들에 들어가는 건 오직 `{capabilityId, envName, allowedHosts}` 세 필드다. credential 값은 어디에도 노출되지 않는다.
-- 허용된 호스트에 HTTPS 요청을 보낼 때, 에이전트는 capability id 와 함께 cloud-api 의 loopback route 를 호출한다. cloud-api 가 `Authorization: Bearer <value>` 헤더를 **서버 사이드에서 주입**하고, upstream 응답만 에이전트에게 돌려준다. 에이전트는 값을 절대 못 본다.
+- 허용된 호스트에 HTTPS 요청을 보낼 때, 에이전트는 capability id와 함께 cloud-api의 internal route를 호출한다. cloud-api가 `Authorization: Bearer <value>` 헤더를 **서버 사이드에서 주입**하고 upstream 응답만 돌려준다. 에이전트는 값을 보지 않는다.
 - 허용 호스트 목록은 SKILL.md 의 `broker_allowed_hosts` 블록에서 읽는다 (YAML list, exact hostname 만 허용, 와일드카드·포트·scheme 불가). 누락 또는 빈 리스트면 이 스킬의 credential은 capability가 **아예 프로비전되지 않는다**. fail-closed.
 - capability 는 `(accountId, container)` 에 scoped 되고, per-turn TTL(5분) 과 최대 5회 사용 한도를 갖는다. turn 이 끝나면 broker key 와 capability 가 함께 폐기된다.
 
-이 경로는 저장소 compromis(ciphertext at rest)와 Hermes 모델 compromis(평문이 stream/handle에 없음)를 막는다. 다만 cloud-api 호스트 전체 compromis는 방어하지 못한다. 호스트가 털리면 decrypted 값이 process memory 에서 읽힐 수 있다. 이것은 honest residual risk 로 받아들인다.
+이 경로는 `api_key`의 scalar `value`에만 적용한다. Login username/password와 note는 scalar Bearer broker로 보내지 않는다.
+
+### Credential Actions (`vault-run`)
+
+Dolshoi Cloud는 모든 vault item에 turn-scoped `vault-run` capability를 제공한다.
+
+- `vault-run <capability_id> search|seats|reserve|cancel|list` 같은 서비스별 action은 서버가 credential을 주입하고 business output만 반환하는 **blind action**이다. 제공되면 이 경로를 우선한다.
+- 공통 `vault-run <capability_id> get`은 저장된 평문을 JSON으로 반환한다 (`login` → `{username, password}`, `api_key`/`note` → `{value}`). 이것은 blind broker가 아니라 **audited plaintext reveal**이다. 직접 CLI/스크립트 실행에 값이 꼭 필요할 때만 짧은 `set +x` subshell에서 명령 접두 환경변수로 사용하고, 채팅·로그·파일에 출력하지 않는다.
+- capability와 broker key는 account/container/turn에 scope되며 만료·사용 제한을 가진다. `get`으로 반환된 값은 agent process memory를 통과하므로 blind action보다 신뢰 폭이 넓다.
+
+저장소 compromise(ciphertext at rest)와 blind action 경로의 Hermes 모델 compromise(평문이 stream/handle에 없음)는 방어한다. `get`을 사용한 agent process나 cloud-api 호스트 전체 compromise는 방어하지 못한다.
 
 신뢰 경계 세부 사항과 broker route 주소는 cloud-api 의 `apps/cloud-api/docker/README.md` 와 `docs/internal/bitwarden-credential-engine.md` (Pattern B) 를 참고한다.
 
@@ -21,34 +35,24 @@ Dolshoi Cloud stores the environment-variable bindings for a credential as a
 structured object with optional `username`, `password`, and `value` fields.
 The names are metadata; the secret values stay encrypted in cloud-api.
 
-- `login` uses the username/password pair only when the skill explicitly opts
-  into `legacy_env_injection: true`. Login credentials are not sent through the
-  scalar Bearer broker.
-- `api_key` uses the `value` field through the broker. A legacy `envName` is
-  treated as the `value` binding during migration.
-- `note` is never injected into an agent turn.
+- `login`은 service action 또는 공통 `get`에서 username/password pair로 사용한다. Scalar Bearer broker에는 보내지 않는다.
+- `api_key`는 blind scalar broker에서 `value`를 쓰거나 공통 `get`으로 명시적으로 reveal할 수 있다.
+- `note`는 scalar broker에 들어가지 않지만 공통 `get`으로 reveal할 수 있다.
 
-Skills should declare only the environment-variable names they need. The
-broker handle remains opaque and contains no field values.
+Skills should declare only the environment-variable names they need. Opaque broker/action handles contain no field values; `get` output is the explicit exception and must be handled as plaintext.
 
-## Legacy plaintext env (opt-in)
+## Generic/local/self-hosted credential resolution
 
-아래 섹션들이 설명하는 `~/.config/k-skill/secrets.env` 평문 경로는 기본값이 아니다. 이 경로를 켜려면 SKILL.md frontmatter 에 `legacy_env_injection: true` 를 **명시적으로** 적어야 한다 (YAML `yes`/`on` 등은 무시되고 리터럴 `true` 만 인정). 새 스킬은 기본값(`false`)을 그대로 써서 broker 경로를 타는 것을 권장한다.
-
-평문 주입이 켜진 스킬은 turn 종료 후 `secrets.env` 가 즉시 정리되고, 모든 읽기/쓰기가 audit log 에 기록된다. 다만 값이 에이전트 컨테이너 filesystem 에 잠깐이라도 평문으로 존재하므로 broker 경로보다 신뢰 폭이 넓다. 필요한 경우에만 켠다.
-
-## Credential resolution order
-
-모든 credential-bearing 스킬은 아래 우선순위를 따른다.
+아래 순서는 Dolshoi Cloud가 아닌 generic/local/self-hosted runtime에만 적용한다. Dolshoi Cloud는 위 broker/actions 경로를 사용하며 `secrets.env`를 agent 환경에 자동 주입하지 않는다.
 
 1. **이미 환경변수에 있으면** 그대로 사용한다.
 2. **에이전트가 자체 secret vault(1Password CLI, Bitwarden CLI, macOS Keychain 등)를 사용 중이면** 거기서 꺼내 환경변수로 주입해도 된다.
 3. **`~/.config/k-skill/secrets.env`** (기본 fallback) — plain dotenv 파일, 퍼미션 `0600`.
-4. **아무것도 없으면** 유저에게 물어서 2 또는 3에 저장한다.
+4. **아무것도 없으면** 사용자에게 host secret store 설정을 요청하고 멈춘다. 값을 채팅으로 받지 않는다.
 
-기본 경로에 저장하는 것은 fallback일 뿐, 강제가 아니다.
+`secrets.env`는 portable fallback일 뿐 강제가 아니며, Cloud credential contract가 아니다.
 
-## Default secrets file
+## Generic/local default secrets file
 
 - 경로: `~/.config/k-skill/secrets.env`
 - 형식: plain dotenv (`KEY=value`, 한 줄에 하나)
@@ -93,8 +97,9 @@ KSKILL_PROXY_BASE_URL=
 
 인증이 필요한 스킬에서 필요한 값이 없으면 우회하지 않는다.
 
-- 어떤 값이 비어 있는지 정확한 환경변수 이름으로 사용자에게 알려준다
-- credential resolution order에 따라 확보한다
+- Dolshoi Cloud에서는 `vault-run credential-request request <항목이름> <login|api_key|note>`로 입력 폼을 띄우고 현재 턴을 멈춘다
+- generic/local/self-hosted runtime에서는 필요한 환경변수 이름을 알리고 위 local resolution order에 따라 host secret store 설정을 요청한다
+- 어느 runtime에서도 값을 채팅으로 받지 않는다
 - 대체 사이트, 대체 API, 하드코딩 같은 우회 경로를 찾지 않는다
 - 시크릿이 없다는 이유로 다른 서비스나 비공식 우회 수단을 자동 채택하지 않는다
 
@@ -104,7 +109,7 @@ KSKILL_PROXY_BASE_URL=
 - 스킬 문서 안에 예시용 실비밀번호를 쓰기
 - 시크릿이 없다는 이유로 다른 서비스나 비공식 우회 수단을 자동 채택하기
 
-## Threat model
+## Generic/local `secrets.env` threat model
 
 - `~/.config/k-skill/secrets.env`는 plain dotenv 파일이다
 - 파일 퍼미션 `0600`으로 같은 머신의 다른 유저로부터 보호한다
@@ -141,4 +146,4 @@ KSKILL_PROXY_BASE_URL=
 `LAW_OC` 는 법제처 Open API(`open.law.go.kr`)를 호출할 때 쓰는 표준 식별자다. 한국 법령 검색은 기본 hosted proxy(`k-skill-proxy.nomadamas.org`)의 `/v1/korean-law/...` 라우트가 `LAW_OC` 와 브라우저 User-Agent/Referer 를 proxy 서버에서만 주입하므로 사용자 쪽 키가 불필요하다. `LAW_OC` 는 self-host proxy 운영자 문맥에서만 서버에 넣는다. `DATA_GO_KR_API_KEY` 는 프록시 운영자 문맥에서만 서버에 넣는다. 부동산 실거래가 조회는 기본 hosted proxy(`k-skill-proxy.nomadamas.org`)를 경유하므로 사용자 쪽 키가 불필요하다. 생활쓰레기 배출정보 조회는 `k-skill-proxy`의 `/v1/household-waste/info` 라우트를 거쳐 `serviceKey`(`DATA_GO_KR_API_KEY`)를 proxy 서버에서 주입하므로 사용자 쪽 키가 불필요하다. 의약품 안전 체크도 `k-skill-proxy`의 `/v1/mfds/drug-safety/lookup` 라우트를 거쳐 `DATA_GO_KR_API_KEY` 를 proxy 서버에서만 주입하므로 사용자 쪽 키가 불필요하다. 식품 안전 체크는 `k-skill-proxy`의 `/v1/mfds/food-safety/search` 라우트를 거쳐 `DATA_GO_KR_API_KEY` 및 선택적 `FOODSAFETYKOREA_API_KEY` 를 proxy 서버에서만 주입하므로 사용자 쪽 키가 불필요하다. 한국 주식 정보 조회도 기본 hosted proxy를 경유하므로 사용자 쪽 `KRX_API_KEY` 가 불필요하다. `KRX_API_KEY` 는 self-host proxy 운영자 문맥에서만 서버에 넣는다. KOSIS 일반 조회도 기본 hosted proxy를 경유하므로 사용자 쪽 KOSIS 키가 불필요하다. `KOSIS_API_KEY` 또는 `KSKILL_KOSIS_API_KEY` 는 self-host proxy 운영자, direct 호출, 또는 bigdata 호출 문맥에서만 쓴다. Kakao Local geocoding도 기본 hosted proxy를 경유하므로 사용자 쪽 `KAKAO_REST_API_KEY` 가 불필요하다. `KAKAO_REST_API_KEY` 는 self-host proxy 운영자 문맥에서만 서버에 넣는다. 근처 가장 싼 주유소 찾기는 기본 hosted proxy를 경유하므로 사용자 쪽 `OPINET_API_KEY` 가 불필요하다. `OPINET_API_KEY` 는 프록시 운영자 문맥에서만 서버에 넣는다. 창업진흥원 K-Startup 조회도 `k-skill-proxy`의 `/v1/kstartup/*` 라우트를 거쳐 `ServiceKey`(`DATA_GO_KR_API_KEY`)를 proxy 서버에서만 주입하므로 사용자 쪽 키가 불필요하다. `KSKILL_KSTARTUP_API_KEY` 는 `--direct` 호출 문맥에서만 사용자 쪽에 둔다. `KIPRIS_PLUS_API_KEY` 는 한국 특허 정보 검색 helper가 KIPRIS Plus Open API에 보낼 `ServiceKey` 값을 담는 표준 변수명이다. 공공데이터포털에서 복사한 percent-encoded key도 helper가 한 번 정규화한 뒤 요청한다. public 공유용 tunnel/auth/operator secret은 사용자 기본 secrets 파일에 넣지 않는다. 프록시 운영자 문맥에서는 upstream 환경변수 `SEOUL_OPEN_API_KEY`, `KMA_OPEN_API_KEY`, `AIR_KOREA_OPEN_API_KEY`, `HRFCO_OPEN_API_KEY`, `OPINET_API_KEY`, `DATA_GO_KR_API_KEY`, `FOODSAFETYKOREA_API_KEY`, `KRX_API_KEY`, `KOSIS_API_KEY`, `KAKAO_REST_API_KEY`, `LAW_OC` 를 사용할 수 있다. 다만 일반 사용자/client 쪽 기본 secrets 파일에는 넣지 않는다. `KSKILL_PROXY_BASE_URL` 은 별도 self-host proxy를 쓸 때만 넣는다. 서울 지하철, 서울 실시간 혼잡도, 서울 따릉이, 한국 날씨, 미세먼지, 한강 수위, 주유소 가격, 한국 주식 정보 조회, 한국 법령 검색, KOSIS 일반 조회, Kakao Local geocoding, 의약품 안전 체크, 식품 안전 체크는 이 값이 없거나 비어 있으면 기본 hosted proxy(`k-skill-proxy.nomadamas.org`)를 사용한다.
 `KSKILL_POPBILL_LINK_ID`, `KSKILL_POPBILL_SECRET_KEY`, `KSKILL_POPBILL_CORP_NUM`, `KSKILL_POPBILL_USER_ID` 는 팝빌 사용자별 과금/권한 API를 로컬 BYOK 방식으로 호출할 때만 사용한다. hosted proxy에 넣지 않고, 테스트/운영 환경을 혼동하지 않으며, 실제 SecretKey·사업자번호·수신자 연락처·계좌번호는 문서/PR/로그에 남기지 않는다.
 
-이 레포의 credential-bearing skill은 전부 이 정책을 전제로 작성한다. 자세한 공통 설치 절차는 [공통 설정 가이드](setup.md)를 본다.
+이 레포의 credential-bearing skill은 Cloud와 generic/local/self-hosted 경로를 명시적으로 구분한다. 자세한 공통 설치 절차는 [공통 설정 가이드](setup.md)를 본다.

--- a/docs/security-and-secrets.md
+++ b/docs/security-and-secrets.md
@@ -2,6 +2,41 @@
 
 `k-skill`은 **필요한 환경변수 이름만 선언**하고, 그 값을 어떻게 공급하느냐는 에이전트의 자유에 맡긴다.
 
+## Credential broker (default path)
+
+Dolshoi Cloud(`apps/cloud-api`)에서 스킬이 실행될 때, 기본적으로 credential 평문 값은 에이전트에게 **전달되지 않는다**. 대신 cloud-api 가 값을 복호화해 in-process 에 보관하고, 에이전트에게는 불투명(opaque) capability 핸들만 넘긴다.
+
+- 핸들에 들어가는 건 오직 `{capabilityId, envName, allowedHosts}` 세 필드다. credential 값은 어디에도 노출되지 않는다.
+- 허용된 호스트에 HTTPS 요청을 보낼 때, 에이전트는 capability id 와 함께 cloud-api 의 loopback route 를 호출한다. cloud-api 가 `Authorization: Bearer <value>` 헤더를 **서버 사이드에서 주입**하고, upstream 응답만 에이전트에게 돌려준다. 에이전트는 값을 절대 못 본다.
+- 허용 호스트 목록은 SKILL.md 의 `broker_allowed_hosts` 블록에서 읽는다 (YAML list, exact hostname 만 허용, 와일드카드·포트·scheme 불가). 누락 또는 빈 리스트면 이 스킬의 credential은 capability가 **아예 프로비전되지 않는다**. fail-closed.
+- capability 는 `(accountId, container)` 에 scoped 되고, per-turn TTL(5분) 과 최대 5회 사용 한도를 갖는다. turn 이 끝나면 broker key 와 capability 가 함께 폐기된다.
+
+이 경로는 저장소 compromis(ciphertext at rest)와 Hermes 모델 compromis(평문이 stream/handle에 없음)를 막는다. 다만 cloud-api 호스트 전체 compromis는 방어하지 못한다. 호스트가 털리면 decrypted 값이 process memory 에서 읽힐 수 있다. 이것은 honest residual risk 로 받아들인다.
+
+신뢰 경계 세부 사항과 broker route 주소는 cloud-api 의 `apps/cloud-api/docker/README.md` 와 `docs/internal/bitwarden-credential-engine.md` (Pattern B) 를 참고한다.
+
+### Structured credential fields
+
+Dolshoi Cloud stores the environment-variable bindings for a credential as a
+structured object with optional `username`, `password`, and `value` fields.
+The names are metadata; the secret values stay encrypted in cloud-api.
+
+- `login` uses the username/password pair only when the skill explicitly opts
+  into `legacy_env_injection: true`. Login credentials are not sent through the
+  scalar Bearer broker.
+- `api_key` uses the `value` field through the broker. A legacy `envName` is
+  treated as the `value` binding during migration.
+- `note` is never injected into an agent turn.
+
+Skills should declare only the environment-variable names they need. The
+broker handle remains opaque and contains no field values.
+
+## Legacy plaintext env (opt-in)
+
+아래 섹션들이 설명하는 `~/.config/k-skill/secrets.env` 평문 경로는 기본값이 아니다. 이 경로를 켜려면 SKILL.md frontmatter 에 `legacy_env_injection: true` 를 **명시적으로** 적어야 한다 (YAML `yes`/`on` 등은 무시되고 리터럴 `true` 만 인정). 새 스킬은 기본값(`false`)을 그대로 써서 broker 경로를 타는 것을 권장한다.
+
+평문 주입이 켜진 스킬은 turn 종료 후 `secrets.env` 가 즉시 정리되고, 모든 읽기/쓰기가 audit log 에 기록된다. 다만 값이 에이전트 컨테이너 filesystem 에 잠깐이라도 평문으로 존재하므로 broker 경로보다 신뢰 폭이 넓다. 필요한 경우에만 켠다.
+
 ## Credential resolution order
 
 모든 credential-bearing 스킬은 아래 우선순위를 따른다.

--- a/srt-booking/SKILL.md
+++ b/srt-booking/SKILL.md
@@ -42,21 +42,32 @@ metadata:
 
 ### Credential resolution order
 
-1. **시스템 프롬프트의 `# Credential Actions` 섹션에 SRT capability가 있으면** 그것을 사용한다.
-   서비스 액션(`vault-run <capability_id> search|seats|reserve|cancel|list`)이 있으면 그걸 우선 쓰고,
-   이 레시피의 스크립트를 직접 돌릴 때는 `vault-run <capability_id> get`으로 값을 가져와
-   `KSKILL_SRT_ID`/`KSKILL_SRT_PASSWORD`를 **명령 접두 env**로 전달한다:
+1. **Dolshoi Cloud 시스템 프롬프트의 `# Credential Actions` 섹션에 SRT capability가 있으면** 그것을 사용한다.
+   서비스 액션(`vault-run <capability_id> search|seats|reserve|cancel|list`)이 있으면 credential이 노출되지 않는 그 action을 우선 쓴다. 이 레시피의 스크립트를 직접 돌려야 할 때만 audited `vault-run <capability_id> get`으로 값을 가져와 `KSKILL_SRT_ID`/`KSKILL_SRT_PASSWORD`를 **명령 접두 env**로 전달한다:
 
    ```bash
-   CREDS=$(DOLSHOI_ACTION_BROKER_URL=<프롬프트 값> DOLSHOI_ACTION_BROKER_KEY=<프롬프트 값> vault-run <capability_id> get)
-   KSKILL_SRT_ID=$(printf '%s' "$CREDS" | python3 -c 'import json,sys;print(json.load(sys.stdin)["username"])') \
-   KSKILL_SRT_PASSWORD=$(printf '%s' "$CREDS" | python3 -c 'import json,sys;print(json.load(sys.stdin)["password"])') \
-   python3 scripts/srt_booking.py ...
+   (
+     set +x
+     CREDS="$(DOLSHOI_ACTION_BROKER_URL=<프롬프트 값> DOLSHOI_ACTION_BROKER_KEY=<프롬프트 값> vault-run <capability_id> get)" || exit 1
+     SRT_ID="$(printf '%s' "$CREDS" | python3 -c 'import json,sys; v=json.load(sys.stdin)["username"]; print(v,end="") if isinstance(v,str) and v else sys.exit(1)')" || { unset CREDS; exit 1; }
+     SRT_PASSWORD="$(printf '%s' "$CREDS" | python3 -c 'import json,sys; v=json.load(sys.stdin)["password"]; print(v,end="") if isinstance(v,str) and v else sys.exit(1)')" || { unset CREDS SRT_ID; exit 1; }
+     unset CREDS
+     [ -n "$SRT_ID" ] && [ -n "$SRT_PASSWORD" ] || { unset SRT_ID SRT_PASSWORD; exit 1; }
+     KSKILL_SRT_ID="$SRT_ID" KSKILL_SRT_PASSWORD="$SRT_PASSWORD" python3 scripts/srt_booking.py ...
+     unset SRT_ID SRT_PASSWORD
+   )
    ```
 
 2. **이미 환경변수에 있으면** 그대로 사용한다.
-3. **둘 다 없으면** 유저에게 볼트(자격증명 탭)에 SRT 로그인을 저장해 달라고 안내하고 멈춘다.
-   비밀번호를 채팅으로 받지 않는다.
+3. **Cloud가 아닌 generic/local/self-hosted runtime이면** host vault(1Password CLI, Bitwarden CLI, macOS Keychain 등), 그다음 `~/.config/k-skill/secrets.env`(`0600`)에서 현재 명령에만 주입할 수 있다.
+4. **Dolshoi Cloud에서 capability와 환경변수가 모두 없으면** 아래 명령으로 SRT login 입력 폼을 띄우고 멈춘다. 비밀번호를 채팅으로 받지 않는다.
+
+   ```bash
+   DOLSHOI_ACTION_BROKER_URL=<프롬프트 값> DOLSHOI_ACTION_BROKER_KEY=<프롬프트 값> \
+     vault-run credential-request request SRT login
+   ```
+
+5. **generic/local/self-hosted runtime에도 credential이 없으면** 사용자에게 host vault 또는 `secrets.env` 설정을 요청하고 멈춘다. 비밀번호를 채팅으로 받지 않는다.
 
 ## Inputs
 

--- a/srt-booking/SKILL.md
+++ b/srt-booking/SKILL.md
@@ -54,20 +54,21 @@ metadata:
      unset CREDS
      [ -n "$SRT_ID" ] && [ -n "$SRT_PASSWORD" ] || { unset SRT_ID SRT_PASSWORD; exit 1; }
      KSKILL_SRT_ID="$SRT_ID" KSKILL_SRT_PASSWORD="$SRT_PASSWORD" python3 scripts/srt_booking.py ...
+     SRT_STATUS=$?
      unset SRT_ID SRT_PASSWORD
+     exit "$SRT_STATUS"
    )
    ```
 
-2. **이미 환경변수에 있으면** 그대로 사용한다.
-3. **Cloud가 아닌 generic/local/self-hosted runtime이면** host vault(1Password CLI, Bitwarden CLI, macOS Keychain 등), 그다음 `~/.config/k-skill/secrets.env`(`0600`)에서 현재 명령에만 주입할 수 있다.
-4. **Dolshoi Cloud에서 capability와 환경변수가 모두 없으면** 아래 명령으로 SRT login 입력 폼을 띄우고 멈춘다. 비밀번호를 채팅으로 받지 않는다.
+2. **Cloud가 아닌 generic/local/self-hosted runtime이면** 이미 설정된 환경변수를 먼저 사용한다. 없으면 host vault(1Password CLI, Bitwarden CLI, macOS Keychain 등), 그다음 `~/.config/k-skill/secrets.env`(`0600`)에서 현재 명령에만 주입할 수 있다.
+3. **Dolshoi Cloud에서 SRT capability가 없으면** 아래 명령으로 SRT login 입력 폼을 띄우고 멈춘다. 비밀번호를 채팅으로 받지 않는다.
 
    ```bash
    DOLSHOI_ACTION_BROKER_URL=<프롬프트 값> DOLSHOI_ACTION_BROKER_KEY=<프롬프트 값> \
      vault-run credential-request request SRT login
    ```
 
-5. **generic/local/self-hosted runtime에도 credential이 없으면** 사용자에게 host vault 또는 `secrets.env` 설정을 요청하고 멈춘다. 비밀번호를 채팅으로 받지 않는다.
+4. **generic/local/self-hosted runtime에도 credential이 없으면** 사용자에게 host vault 또는 `secrets.env` 설정을 요청하고 멈춘다. 비밀번호를 채팅으로 받지 않는다.
 
 ## Inputs
 

--- a/srt-booking/SKILL.md
+++ b/srt-booking/SKILL.md
@@ -42,12 +42,21 @@ metadata:
 
 ### Credential resolution order
 
-1. **이미 환경변수에 있으면** 그대로 사용한다.
-2. **에이전트가 자체 secret vault(1Password CLI, Bitwarden CLI, macOS Keychain 등)를 사용 중이면** 거기서 꺼내 환경변수로 주입해도 된다.
-3. **`~/.config/k-skill/secrets.env`** (기본 fallback) — plain dotenv 파일, 퍼미션 `0600`.
-4. **아무것도 없으면** 유저에게 물어서 2 또는 3에 저장한다.
+1. **시스템 프롬프트의 `# Credential Actions` 섹션에 SRT capability가 있으면** 그것을 사용한다.
+   서비스 액션(`vault-run <capability_id> search|seats|reserve|cancel|list`)이 있으면 그걸 우선 쓰고,
+   이 레시피의 스크립트를 직접 돌릴 때는 `vault-run <capability_id> get`으로 값을 가져와
+   `KSKILL_SRT_ID`/`KSKILL_SRT_PASSWORD`를 **명령 접두 env**로 전달한다:
 
-기본 경로에 저장하는 것은 fallback일 뿐, 강제가 아니다.
+   ```bash
+   CREDS=$(DOLSHOI_ACTION_BROKER_URL=<프롬프트 값> DOLSHOI_ACTION_BROKER_KEY=<프롬프트 값> vault-run <capability_id> get)
+   KSKILL_SRT_ID=$(printf '%s' "$CREDS" | python3 -c 'import json,sys;print(json.load(sys.stdin)["username"])') \
+   KSKILL_SRT_PASSWORD=$(printf '%s' "$CREDS" | python3 -c 'import json,sys;print(json.load(sys.stdin)["password"])') \
+   python3 scripts/srt_booking.py ...
+   ```
+
+2. **이미 환경변수에 있으면** 그대로 사용한다.
+3. **둘 다 없으면** 유저에게 볼트(자격증명 탭)에 SRT 로그인을 저장해 달라고 안내하고 멈춘다.
+   비밀번호를 채팅으로 받지 않는다.
 
 ## Inputs
 


### PR DESCRIPTION
## Summary

- document the Dolshoi Cloud scalar API-key broker as a blind, exact-host, fail-closed path;
- distinguish blind service actions from the universal audited `vault-run get` plaintext reveal;
- remove the nonexistent Cloud `legacy_env_injection` / plaintext `secrets.env` path;
- keep environment, host-vault, and `0600 secrets.env` fallback explicitly portable for generic/local/self-hosted runtimes;
- update SRT guidance to prefer blind service actions, use a short `set +x` fail-closed direct-command flow, preserve helper exit status through cleanup, and request missing login with `vault-run credential-request request SRT login`.

## Validation

- `node --test scripts/skill-docs.test.js`: 148/148 passed
- `./scripts/validate-skills.sh`: passed
- `npm run typecheck`: passed
- `npm run lint` with Python 3.12: passed
- `git diff --check`: passed
- synthetic SRT flow: valid JSON reaches command-prefix env; malformed/missing JSON stops before command; helper exit 23 remains 23; no plaintext files written

## Integration context

- PR #443 also changes all three documentation surfaces and should preserve these trust-boundary distinctions when conflicts are resolved.
- PR #444 is stacked on #443 and moves skill instructions into generated/canonical `instruction.md` locations. If it lands first, port the SRT credential block and exit-status behavior into that source of truth rather than choosing one conflict side wholesale.
- Issue #458 tracks preservation of the SRT failure/env-scope contract through merge ordering.

No BrowserOS content or runtime implementation is added by this PR.
