### PR TITLE
fix(deps): bump fast-uri and find-my-way to patch published advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -752,9 +752,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -825,9 +825,9 @@
       }
     },
     "node_modules/fastify/node_modules/fast-uri": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.1.tgz",
-      "integrity": "sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.2.tgz",
+      "integrity": "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==",
       "funding": [
         {
           "type": "github",
@@ -859,9 +859,9 @@
       }
     },
     "node_modules/find-my-way": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.6.0.tgz",
-      "integrity": "sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.7.0.tgz",
+      "integrity": "sha512-f2JHn75x2JlwUwLenZypgczR7YWMb/uO9BvUXtus+JMgkbIkLADd38cI4EiV+OQqrGo1Zlq6V8wnqMJ8e62wUQ==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -1959,7 +1959,7 @@
       }
     },
     "packages/gangnamunni-clinic-search": {
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "bin": {
         "gangnamunni-clinic-search": "src/cli.js"
@@ -1990,7 +1990,7 @@
       }
     },
     "packages/housing-official-price": {
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2016,7 +2016,7 @@
     },
     "packages/k-skill-cli": {
       "name": "@nomadamas/k-skill",
-      "version": "0.1.0",
+      "version": "0.2.2",
       "license": "MIT",
       "bin": {
         "k-skill": "bin/k-skill.js"
@@ -2026,7 +2026,7 @@
       }
     },
     "packages/k-skill-proxy": {
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "fastify": "^5.10.0"


### PR DESCRIPTION
Lockfile-only bump for two published advisories in transitive dependencies of `fastify`.

| Package | From | To | Advisory | Severity |
| --- | --- | --- | --- | --- |
| `fast-uri` | 3.1.4 / 4.1.1 | 3.1.5 / 4.1.2 | [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) — host confusion via backslash authority introducer | 7.5 |
| `find-my-way` | 9.6.0 | 9.7.0 | [GHSA-c96f-x56v-gq3h](https://github.com/advisories/GHSA-c96f-x56v-gq3h) — DoS with HTTP/2 | 7.5 |

Both packages reach the tree only through `fastify ^5.10.0`. Every fix is inside the already-declared range, so **`fastify` and all `package.json` files are unchanged** — this is a `package-lock.json` refresh only.

### Reachability, stated honestly

- **`find-my-way` (HTTP/2 DoS) is not reachable in the current `k-skill-proxy` deployment.** `Fastify({...})` in `packages/k-skill-proxy/src/server.js` does not set `http2`, and I found no `http2` reference anywhere under `packages/k-skill-proxy/src/`. Bumping it is hygiene, not an active fix.
- **`fast-uri` is the one that matters here**, since `k-skill-proxy` is a public, unauthenticated service that parses and forwards URLs. I did not build a working exploit against the proxy, so please treat this as "patch the known-vulnerable version", not "confirmed exploitable".

### Verification

- `osv-scanner scan source --recursive --no-ignore` on the updated lockfile: **zero residual advisories** (3 before).
- OSV API queried per target version — `fast-uri@3.1.5`, `fast-uri@4.1.2`, `find-my-way@9.7.0` all return no vulns.
- `node --test` in `packages/k-skill-proxy`: **373/373 pass** against the updated tree.

### One thing to look at

The diff also syncs four workspace versions that were **already stale in the lockfile before this change** — the lock lagged the packages' own `package.json`:

| Workspace | lockfile (before) | its `package.json` |
| --- | --- | --- |
| `packages/gangnamunni-clinic-search` | 0.2.0 | 0.2.1 |
| `packages/housing-official-price` | 0.1.0 | 0.2.0 |
| `packages/k-skill-cli` | 0.1.0 | 0.2.2 |
| `packages/k-skill-proxy` | 0.10.0 | 0.10.1 |

`npm` rewrote these to match the manifests. I left them in rather than hand-editing the lockfile back, but they are unrelated to the security bump — happy to split them out or drop them if you would rather keep this PR to the three dependency lines.

Detected by [osv-scanner](https://google.github.io/osv-scanner/). No code changes outside the lockfile.

---
Filed by [Aeon](https://github.com/aeonframework/aeon).
