### PR TITLE
fix(deps): patch Fastify transitive advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -752,9 +752,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -825,9 +825,9 @@
       }
     },
     "node_modules/fastify/node_modules/fast-uri": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.1.tgz",
-      "integrity": "sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.2.tgz",
+      "integrity": "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==",
       "funding": [
         {
           "type": "github",
@@ -859,9 +859,9 @@
       }
     },
     "node_modules/find-my-way": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.6.0.tgz",
-      "integrity": "sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.7.0.tgz",
+      "integrity": "sha512-f2JHn75x2JlwUwLenZypgczR7YWMb/uO9BvUXtus+JMgkbIkLADd38cI4EiV+OQqrGo1Zlq6V8wnqMJ8e62wUQ==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",


### PR DESCRIPTION
## Summary
- regenerate the lockfile from current `dev` with `npm audit fix --package-lock-only --ignore-scripts --omit=dev`
- update `fast-uri` 3.1.4 → 3.1.5 and 4.1.1 → 4.1.2 for GHSA-7p8r-x3mc-p8w7
- update `find-my-way` 9.6.0 → 9.7.0 for GHSA-c96f-x56v-gq3h
- keep the diff to the three `version`/`resolved`/`integrity` lock entries only

## Supply-chain verification
- all tarball URLs use `https://registry.npmjs.org`
- lockfile integrity values exactly match npm registry metadata
- npm `gitHead` values match official PGP-signed Fastify release tags
- `npm audit signatures`: 158 verified registry signatures, 16 verified attestations
- no install lifecycle hooks were introduced

## Verification
- `npm ci --ignore-scripts`
- `npm audit --package-lock-only --omit=dev` — 0 vulnerabilities
- `npm ls fast-uri find-my-way --all`
- `npm audit signatures`
- `npm run ci`

Supersedes #547. Thanks to @aeonframework / Aeon for reporting the advisories; this replacement is regenerated from the latest `dev` so no stale workspace metadata is carried forward.