### PR TITLE
perf(seoul-weather-risk): hosted 단일 경로와 일반 조회 1회 요청으로 정리

### DIFF
--- a/.changeset/hosted-weather-risk-only.md
+++ b/.changeset/hosted-weather-risk-only.md
@@ -1,0 +1,5 @@
+---
+"@nomadamas/k-skill": patch
+---
+
+seoul-weather-risk helper를 hosted k-skill proxy 전용으로 고정하고, 등록 전 local-direct·Marketplace API key fallback을 제거한다.

--- a/.changeset/seoul-weather-risk-fast-path.md
+++ b/.changeset/seoul-weather-risk-fast-path.md
@@ -1,0 +1,5 @@
+---
+"@nomadamas/k-skill": patch
+---
+
+seoul-weather-risk 일반 조회에 metadata 왕복을 생략하는 `query --fast` 경로를 추가해 hosted data 요청을 한 번으로 줄인다.

--- a/.changeset/windows-python-runner.md
+++ b/.changeset/windows-python-runner.md
@@ -1,0 +1,5 @@
+---
+"@nomadamas/k-skill": patch
+---
+
+fix(k-skill-cli): honor Python runner overrides and use a Windows-compatible default

--- a/docs/features/seoul-weather-risk.md
+++ b/docs/features/seoul-weather-risk.md
@@ -65,7 +65,22 @@ ASK 서울 전용 서비스 키와 upstream origin은 proxy 운영 환경에서�
 
 > 잠실본동의 이번 주 기상 위험 시간대와 각 위험 판정의 근거를 알려줘.
 
-CLI에서 직접 확인하려면 아래 순서대로 실행합니다. 먼저 연결 상태를 확인하고, 제품이 게시 가능한지 확인한 다음, 실제 데이터를 조회합니다.
+일반적인 오늘 위험 시간대 질문은 아래 fast path를 한 번만 실행합니다. bundled 행정동 매핑과 날짜·limit 검증은 유지하면서 hosted data route만 호출하므로 bundle·product metadata 왕복을 생략합니다.
+
+```bash
+npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.py -- query --fast \
+  --product-id weather_place_risk_window \
+  --admin-dong 잠실본동 \
+  --from 2026-08-12 \
+  --to 2026-08-12 \
+  --limit 100
+```
+
+`--fast`에서는 `--filter` 대신 `--admin-dong`, `--gu`, 날짜, `--limit`, `--cursor`를 사용합니다. `product_not_ready` 또는 계약 오류가 나오면 fixture로 대체하지 말고 게시 계약 진단을 수행합니다.
+
+## 게시 계약 진단
+
+아래 단계는 일반 질문마다 실행하지 않고, fast path 오류나 게시 상태 점검이 필요할 때만 실행합니다.
 
 ### 1. 연결·실행 모드 확인
 
@@ -101,7 +116,7 @@ npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.p
 
 제품의 기본 단위(grain)는 `place_id`와 `forecast_at` 조합입니다. `describe` 응답의 `metadata.columns`에서 실제 공개 컬럼을 확인한 뒤 필요한 필터만 사용하세요.
 
-### 4. 행정동으로 조회
+### 4. full-contract 행정동 조회
 
 ```bash
 npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.py -- query \
@@ -111,6 +126,8 @@ npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.p
   --to 2026-08-17 \
   --limit 100
 ```
+
+`--filter`가 필요하면 `--fast`를 빼고 이 full-contract 경로를 사용합니다. data 응답의 `publication_id`, `row_count`, `rows`, `has_more`, `next_cursor`를 확인하고 다음 page에는 같은 publication의 cursor만 재사용합니다.
 
 `--from`과 `--to`에 날짜만 넣으면 KST 기준으로 각각 `00:00:00`, `23:59:59`로 확장됩니다. 특정 시각이 필요하면 `2026-08-11 09:00:00`처럼 명시하세요.
 

--- a/docs/features/seoul-weather-risk.md
+++ b/docs/features/seoul-weather-risk.md
@@ -4,13 +4,22 @@
 
 > 이 결과는 예보값을 기준으로 만든 참고 정보이며, **기상청 공식 특보를 대체하지 않습니다.** 외출·운영·안전 판단에는 공식 기상청 발표를 함께 확인하세요.
 
-## 먼저 알아둘 것
+## 이 기능으로 할 수 있는 일
 
-- 제품은 `weather_place_risk_window` 하나만 제공합니다.
-- 사용자는 `place_id`나 ASK 서울 API Key를 알거나 발급받을 필요가 없습니다.
-- 기본 hosted `k-skill-proxy`가 인증과 ASK 서울 API 호출을 대신합니다.
-- 조회는 읽기 전용이며 SQL, 테이블명, 조인, 집계, 임의 정렬을 입력할 수 없습니다.
-- 현재 행정동 매핑은 `kma_admin_dong_grid_20260325` 버전의 서울 427개 항목을 기준으로 합니다.
+- 서울 행정동 이름으로 장소별 기상 위험 예상 시간대를 조회합니다.
+- 폭염·한파·호우·대설·강풍 후보와 예보 시각(`forecast_at`)을 확인합니다.
+- 동명이명 행정동은 자치구(`--gu`)를 지정해 정확한 장소로 좁힐 수 있습니다.
+- 제품 게시 상태, 공개 컬럼, 페이지별 행 수와 게시 버전(`publication_id`)을 함께 확인합니다.
+
+이 스킬은 ASK 서울 Marketplace의 `weather_place_risk_window` **단일 제품**만 읽습니다. 조회 결과가 없거나 제품이 준비되지 않았을 때 임의의 예시·fixture 데이터를 대신 반환하지 않습니다.
+
+## 먼저 필요한 것
+
+- 인터넷 연결
+- Node.js와 `npx`
+- [공통 설치 가이드](../install.md) 및 [보안/시크릿 정책](../security-and-secrets.md) 확인
+
+사용자 API Key는 필요하지 않습니다. 기본 hosted proxy가 ASK 서울 API 인증을 대신하므로, 일반 사용자는 별도 키를 발급받거나 secrets 파일을 만들지 않아도 됩니다.
 
 ## 설치
 
@@ -20,7 +29,37 @@
 npx --yes skills add NomaDamas/k-skill --skill seoul-weather-risk -g
 ```
 
-## 가장 빠른 사용법
+## 필요한 환경변수
+
+- 없음. `KSKILL_PROXY_BASE_URL`은 self-host 또는 별도 proxy를 사용할 때만 설정하는 선택 항목입니다.
+- 환경변수를 비워 두면 기본 hosted `https://k-skill-proxy.nomadamas.org`를 사용합니다.
+
+ASK 서울 전용 서비스 키와 upstream origin은 proxy 운영 환경에서만 관리합니다. 사용자 환경변수, URL, 명령행 인수, 문서, 로그에는 넣지 않습니다.
+
+## 기본 경로
+
+기본적으로 다음 세 read-only route를 proxy가 중계합니다.
+
+- bundle: `GET /v1/ask-seoul/weather-risk/bundle`
+- product metadata: `GET /v1/ask-seoul/weather-risk/product`
+- data page: `GET /v1/ask-seoul/weather-risk/data`
+
+사용자는 이 route를 직접 조합하기보다 아래 CLI 흐름을 사용하는 것을 권장합니다. proxy 운영·self-host가 필요한 경우에는 [k-skill 프록시 서버 가이드](k-skill-proxy.md)를 참고하세요.
+
+## 입력값
+
+| 입력 | 설명 |
+| --- | --- |
+| `--admin-dong` | 서울 행정동 이름. 내부 `place_id`를 몰라도 됨 |
+| `--gu` | 동명이명 해소용 자치구. `--admin-dong`과 함께 사용 |
+| `--from` / `--to` | KST 기준 조회 범위. 날짜만 입력하면 하루의 시작·끝 시각으로 확장 |
+| `--limit` | 페이지 행 수, `1`~`500`, 기본값 `100` |
+| `--cursor` | 같은 `publication_id`의 다음 페이지를 조회할 때 사용 |
+| `--filter` | `column=value` 형식의 공개 컬럼 필터 |
+
+`--product-id`는 항상 `weather_place_risk_window`를 사용합니다. `--admin-dong`과 `--filter place_id=...`는 동시에 사용할 수 없습니다.
+
+## 기본 흐름
 
 스킬을 설치한 뒤에는 자연어로 다음처럼 요청하면 됩니다.
 
@@ -98,18 +137,6 @@ npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.p
 
 지원하지 않는 이름을 억지로 보정하지 않는 것은 잘못된 장소의 기상 정보를 보여주는 것을 막기 위한 안전장치입니다.
 
-## 조회 옵션
-
-| 옵션 | 필수 | 설명 |
-| --- | --- | --- |
-| `--product-id` | 예 | 항상 `weather_place_risk_window` 사용 |
-| `--admin-dong` | 조건부 | 서울 행정동 이름. `--filter place_id=...`와 동시에 사용할 수 없음 |
-| `--gu` | 아니오 | 동명이명을 자치구로 좁힐 때 `--admin-dong`과 함께 사용 |
-| `--from` / `--to` | 아니오 | KST 조회 시작·종료 시각 또는 날짜 |
-| `--limit` | 아니오 | 한 페이지 행 수, `1`~`500`, 기본값 `100` |
-| `--cursor` | 아니오 | 이전 응답의 `next_cursor`를 같은 publication에서 이어 조회 |
-| `--filter` | 아니오 | `column=value` 형식의 공개 컬럼 필터. 자동화 호환용 `place_id` 필터도 지원 |
-
 `--admin-dong`을 사용하지 않는 기존 자동화는 다음처럼 `place_id`를 직접 필터링할 수 있습니다.
 
 ```bash
@@ -171,7 +198,7 @@ MARKETPLACE_API_KEY=<기존 로컬 Marketplace 키>
 
 이 값은 사용자의 로컬 검증용이며 저장소에 커밋하지 않습니다. API Key를 채팅, 명령행 인수, URL query string, 문서, 로그에 넣지 마세요. hosted proxy 운영용 ASK 서울 전용 서비스 키는 proxy 서버 환경에서만 관리됩니다.
 
-## 이 스킬로 할 수 없는 것
+## 주의할 점
 
 - 기상청 공식 특보를 발령하거나 대체하는 판단
 - 행정동을 좌표·생활권·통칭으로 추정하는 검색

--- a/docs/features/seoul-weather-risk.md
+++ b/docs/features/seoul-weather-risk.md
@@ -186,17 +186,9 @@ npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.p
 
 기본 hosted proxy 경로에서는 사용자 `Authorization` 헤더나 ASK 서울 API Key를 사용하지 않습니다. 사용자는 `KSKILL_PROXY_BASE_URL`을 설정하지 않아도 기본 hosted proxy를 사용합니다.
 
-### self-host 또는 등록 전 로컬 검증
+### self-host proxy 설정
 
-별도 proxy를 사용할 때만 `KSKILL_PROXY_BASE_URL`에 **HTTPS origin**을 설정합니다. 등록 전 ASK 서울 direct API를 검증해야 하는 경우에만 현재 작업 디렉터리의 `.env`에서 local-direct를 명시적으로 켤 수 있습니다.
-
-```text
-KSKILL_LOCAL_DIRECT=1
-ASK_SEOUL_SKILL_API_BASE_URL=https://ask-seoul.kr
-MARKETPLACE_API_KEY=<기존 로컬 Marketplace 키>
-```
-
-이 값은 사용자의 로컬 검증용이며 저장소에 커밋하지 않습니다. API Key를 채팅, 명령행 인수, URL query string, 문서, 로그에 넣지 마세요. hosted proxy 운영용 ASK 서울 전용 서비스 키는 proxy 서버 환경에서만 관리됩니다.
+별도 proxy를 사용할 때만 `KSKILL_PROXY_BASE_URL`에 **HTTPS origin**을 설정합니다. helper는 현재 작업 디렉터리의 `.env`나 사용자 Marketplace API key를 읽지 않으며, hosted proxy 운영용 ASK 서울 전용 서비스 키는 proxy 서버 환경에서만 관리됩니다.
 
 ## 주의할 점
 

--- a/docs/features/seoul-weather-risk.md
+++ b/docs/features/seoul-weather-risk.md
@@ -1,40 +1,199 @@
-# seoul-weather-risk
+# 서울 기상 위험 시간대 조회 가이드
 
-`seoul-weather-risk`는 서울 행정동 이름을 정규 `place_id`로 해석한 뒤 ASK 서울의 장소별 기상 위험 예상 시간대 단일 제품(`weather_place_risk_window`)을 hosted `k-skill-proxy`로 탐색하는 읽기 전용 클라이언트다. 사용자는 내부 ID를 알거나 ASK Seoul API Key를 발급·저장할 필요가 없다.
+`seoul-weather-risk`는 서울 **행정동 이름**으로 장소를 찾고, 해당 장소의 폭염·한파·호우·대설·강풍 **위험 후보 시간대**를 조회하는 읽기 전용 스킬입니다.
 
-## 행정동 입력 계약
+> 이 결과는 예보값을 기준으로 만든 참고 정보이며, **기상청 공식 특보를 대체하지 않습니다.** 외출·운영·안전 판단에는 공식 기상청 발표를 함께 확인하세요.
 
-- 기본 입력은 `--admin-dong <서울 행정동명>`이며 Unicode NFC·공백 정규화 후 정확히 일치시킨다.
-- `kma_admin_dong_grid_20260325` 버전의 427행 bundled reference가 `admin_dong`, `gu`, `place_id`를 연결한다.
-- 동명이명인 `신사동`은 `ambiguous_admin_dong`으로 중단하고 강남구/관악구 중 하나를 `--gu`로 요구한다.
-- 오타·유사 문자열·좌표를 추측하지 않는다. 기존 자동화용 `--filter place_id=...`는 유지하되 `--admin-dong`과 동시 사용은 거부한다.
-- proxy query에는 변환된 `place_id`만 포함하며 `admin_dong`과 `gu`는 전송하지 않는다.
+## 먼저 알아둘 것
 
-## API 계약
+- 제품은 `weather_place_risk_window` 하나만 제공합니다.
+- 사용자는 `place_id`나 ASK 서울 API Key를 알거나 발급받을 필요가 없습니다.
+- 기본 hosted `k-skill-proxy`가 인증과 ASK 서울 API 호출을 대신합니다.
+- 조회는 읽기 전용이며 SQL, 테이블명, 조인, 집계, 임의 정렬을 입력할 수 없습니다.
+- 현재 행정동 매핑은 `kma_admin_dong_grid_20260325` 버전의 서울 427개 항목을 기준으로 합니다.
 
-- Base URL: 기본 `https://k-skill-proxy.nomadamas.org`, self-host 환경에서만 `KSKILL_PROXY_BASE_URL`로 대체한다(HTTPS origin, 끝 슬래시는 정규화).
-- 사용자 인증: 없음. helper는 user-side `Authorization` 헤더를 보내지 않는다.
-- Proxy bundle: `GET /v1/ask-seoul/weather-risk/bundle`
-- Proxy detail: `GET /v1/ask-seoul/weather-risk/product`
-- Proxy data: `GET /v1/ask-seoul/weather-risk/data?limit=1..500&from=&to=&cursor=` 및 `product_row_id`, `place_id`, `forecast_at`, `risk_labels` 등호 필터만 허용한다.
+## 설치
 
-ASK Seoul 전용 서비스 키와 origin은 proxy 운영 환경의 `ASK_SEOUL_KSKILL_API_KEY`, `ASK_SEOUL_SKILL_API_BASE_URL`에만 둔다. Marketplace에서 이 키는 `k-skill-proxy:seoul-weather-risk` / `skill:seoul-weather-risk:read`로 고정 등록되어 bundle·product·data 읽기 외에는 사용할 수 없다. 키는 사용자 환경·문서·shell 인수·로그·응답에 포함하지 않는다. proxy origin이 HTTPS가 아니면 호출 전에 실패한다. 단위 테스트의 loopback mock HTTP만 예외다.
+전체 스킬을 이미 설치했다면 이 단계는 건너뛰어도 됩니다.
 
-## 제품
+```bash
+npx --yes skills add NomaDamas/k-skill --skill seoul-weather-risk -g
+```
 
-| 항목 | 값 |
-|---|---|
-| product_id | `weather_place_risk_window` |
-| 제목 | 장소별 기상 위험 예상 시간대 |
-| grain | `place_id`와 `forecast_at`마다 한 행 |
-| time_axis | `forecast_at` |
-| 설명 | 폭염·한파·호우·대설·강풍 후보를 임계값으로 선별한 예보 기반 참고 정보(기상청 공식 특보 아님) |
+## 가장 빠른 사용법
 
-## 동작 경계
+스킬을 설치한 뒤에는 자연어로 다음처럼 요청하면 됩니다.
 
-- proxy는 이 스킬의 bundle, 단일 product, data 세 route만 allowlist하고, 비허용 query field·중복 field·`limit` 범위 밖 입력을 upstream으로 전달하지 않는다.
-- helper는 bundled reference의 버전, 427행, 필수 필드, 고유 `place_id`, 고유 행정동·자치구 조합을 검증하고 drift 시 `location_mapping_invalid`으로 실패한다.
-- bundle의 `products`가 `weather_place_risk_window` 단일 제품과 다르거나 중복되면 `response_contract_invalid`으로 실패한다.
-- detail/data 응답은 bundle/product ID, page 수, cursor, JSON 계약을 검증한다. malformed JSON도 실패한다.
-- API problem+json의 401, 403, 404, 409, 429, 503은 typed error로 보존한다. `429`의 `Retry-After`와 `request_id`만 안전한 오류 세부 정보로 전달한다.
-- 준비되지 않은 제품(`503`)이나 네트워크 오류를 fixture 또는 synthetic 데이터로 대체하지 않는다.
+> 잠실본동의 이번 주 기상 위험 시간대와 각 위험 판정의 근거를 알려줘.
+
+CLI에서 직접 확인하려면 아래 순서대로 실행합니다. 먼저 연결 상태를 확인하고, 제품이 게시 가능한지 확인한 다음, 실제 데이터를 조회합니다.
+
+### 1. 연결·실행 모드 확인
+
+```bash
+npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.py -- preflight
+```
+
+기본 결과의 `mode`는 `hosted_proxy`입니다. `live_network`가 `false`인 것은 preflight가 네트워크를 호출하지 않는다는 뜻이지, 데이터가 준비됐다는 뜻은 아닙니다.
+
+### 2. 제품 게시 상태 확인
+
+```bash
+npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.py -- catalog
+```
+
+응답에서 다음을 먼저 확인합니다.
+
+| 필드 | 의미 |
+| --- | --- |
+| `registration_ready` | bundle을 현재 조회에 사용할 수 있는지 여부 |
+| `products` | `weather_place_risk_window` 단일 제품이 포함되어 있는지 |
+| `blockers` | 아직 해결되지 않은 게시 차단 사유 |
+| `publication_id` | 현재 게시 버전을 식별하는 값 |
+
+`registration_ready`가 `false`이거나 `blockers`가 남아 있으면 조회 성공으로 간주하지 말고, 게시 상태를 먼저 확인해야 합니다.
+
+### 3. 제품 컬럼과 시간축 확인
+
+```bash
+npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.py -- describe \
+  --product-id weather_place_risk_window
+```
+
+제품의 기본 단위(grain)는 `place_id`와 `forecast_at` 조합입니다. `describe` 응답의 `metadata.columns`에서 실제 공개 컬럼을 확인한 뒤 필요한 필터만 사용하세요.
+
+### 4. 행정동으로 조회
+
+```bash
+npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.py -- query \
+  --product-id weather_place_risk_window \
+  --admin-dong 잠실본동 \
+  --from 2026-08-11 \
+  --to 2026-08-17 \
+  --limit 100
+```
+
+`--from`과 `--to`에 날짜만 넣으면 KST 기준으로 각각 `00:00:00`, `23:59:59`로 확장됩니다. 특정 시각이 필요하면 `2026-08-11 09:00:00`처럼 명시하세요.
+
+## 행정동 입력 규칙
+
+스킬은 입력한 행정동을 로컬 reference에서 결정적으로 `place_id`로 바꾼 뒤, proxy에는 `place_id`만 전달합니다.
+
+| 상황 | 동작 | 예시 |
+| --- | --- | --- |
+| 공식 행정동명 | 정확히 일치하는 항목 사용 | `잠실본동` |
+| 허용된 표기 차이 | 숫자 앞 `제` 생략, 숫자 구분점 `.`·`·`·생략 허용 | `성수2가제3동` → `성수2가3동` |
+| 자치구가 필요한 동명이명 | `--gu`로 자치구를 함께 지정 | `신사동 --gu 강남구` |
+| 오타·생활권·부분 이름 | 추측하지 않고 오류 반환 | `성수동` |
+
+동명이명은 임의로 선택하지 않습니다. 예를 들어 `신사동`은 강남구와 관악구에 모두 있으므로 아래처럼 자치구를 함께 입력해야 합니다.
+
+```bash
+npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.py -- query \
+  --product-id weather_place_risk_window \
+  --admin-dong 신사동 \
+  --gu 강남구 \
+  --limit 100
+```
+
+지원하지 않는 이름을 억지로 보정하지 않는 것은 잘못된 장소의 기상 정보를 보여주는 것을 막기 위한 안전장치입니다.
+
+## 조회 옵션
+
+| 옵션 | 필수 | 설명 |
+| --- | --- | --- |
+| `--product-id` | 예 | 항상 `weather_place_risk_window` 사용 |
+| `--admin-dong` | 조건부 | 서울 행정동 이름. `--filter place_id=...`와 동시에 사용할 수 없음 |
+| `--gu` | 아니오 | 동명이명을 자치구로 좁힐 때 `--admin-dong`과 함께 사용 |
+| `--from` / `--to` | 아니오 | KST 조회 시작·종료 시각 또는 날짜 |
+| `--limit` | 아니오 | 한 페이지 행 수, `1`~`500`, 기본값 `100` |
+| `--cursor` | 아니오 | 이전 응답의 `next_cursor`를 같은 publication에서 이어 조회 |
+| `--filter` | 아니오 | `column=value` 형식의 공개 컬럼 필터. 자동화 호환용 `place_id` 필터도 지원 |
+
+`--admin-dong`을 사용하지 않는 기존 자동화는 다음처럼 `place_id`를 직접 필터링할 수 있습니다.
+
+```bash
+npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.py -- query \
+  --product-id weather_place_risk_window \
+  --filter place_id=seoul_admd_1171065000 \
+  --from 2026-08-11 \
+  --to 2026-08-17 \
+  --limit 100
+```
+
+## 응답 읽는 법
+
+데이터 응답은 한 페이지 단위 JSON입니다.
+
+| 필드 | 확인할 내용 |
+| --- | --- |
+| `publication_id` | 조회한 행이 어느 게시 버전에 속하는지. 페이지를 이어갈 때 같은 값인지 확인 |
+| `row_count` | 이번 응답의 실제 행 수. `rows` 길이와 일치해야 함 |
+| `rows` | `place_id`, `forecast_at`, `risk_labels` 등 공개 컬럼을 가진 행 목록 |
+| `has_more` | 다음 페이지가 있는지 여부 |
+| `next_cursor` | `has_more=true`일 때 다음 요청에 사용할 cursor |
+| `forecast_at` | 위험 후보가 예상되는 예보 시각. 이 제품의 시간축 |
+| `risk_labels` | 폭염·한파·호우·대설·강풍 등 위험 후보 라벨 |
+
+여러 페이지를 조회할 때는 **같은 `publication_id`의 `next_cursor`만** 재사용합니다. 게시 버전이 바뀌어 `409 cursor_expired`가 나오면 cursor를 계속 재시도하지 말고 첫 페이지부터 다시 조회하세요.
+
+## 오류가 나면
+
+| 오류 코드 | 의미 | 대응 |
+| --- | --- | --- |
+| `unknown_admin_dong` | reference에 없는 행정동·자치구 | 공식 행정동명을 다시 입력 |
+| `ambiguous_admin_dong` | 동명이명이라 자치구가 필요함 | `--gu`를 추가 |
+| `conflicting_location_input` | `--admin-dong`과 `place_id` 필터를 동시에 사용함 | 둘 중 하나만 사용 |
+| `invalid_limit` | `--limit`이 1~500 범위를 벗어남 | 범위 안의 값으로 재시도 |
+| `product_not_ready` (503) | 제품이 아직 게시 준비되지 않음 | `catalog`의 `registration_ready`와 `blockers` 확인 |
+| `rate_limited` (429) | 호출 한도 초과 | 응답의 `Retry-After`를 따르고 재시도 |
+| `cursor_expired` (409) | publication이 바뀌어 cursor가 만료됨 | 첫 페이지부터 새로 조회 |
+| `response_contract_invalid` | API 응답 계약 또는 단일 제품 계약이 바뀜 | 성공 데이터로 처리하지 말고 운영자에게 신고 |
+| `network_error` | proxy 연결 실패 | 네트워크와 `KSKILL_PROXY_BASE_URL` 설정 확인 |
+
+`401`, `403`, `503` 또는 네트워크 오류가 발생했을 때 fixture·예시·추정값을 실제 결과처럼 사용하지 않습니다.
+
+## 인증과 보안
+
+### 일반 사용자: 별도 API Key 없음
+
+기본 hosted proxy 경로에서는 사용자 `Authorization` 헤더나 ASK 서울 API Key를 사용하지 않습니다. 사용자는 `KSKILL_PROXY_BASE_URL`을 설정하지 않아도 기본 hosted proxy를 사용합니다.
+
+### self-host 또는 등록 전 로컬 검증
+
+별도 proxy를 사용할 때만 `KSKILL_PROXY_BASE_URL`에 **HTTPS origin**을 설정합니다. 등록 전 ASK 서울 direct API를 검증해야 하는 경우에만 현재 작업 디렉터리의 `.env`에서 local-direct를 명시적으로 켤 수 있습니다.
+
+```text
+KSKILL_LOCAL_DIRECT=1
+ASK_SEOUL_SKILL_API_BASE_URL=https://ask-seoul.kr
+MARKETPLACE_API_KEY=<기존 로컬 Marketplace 키>
+```
+
+이 값은 사용자의 로컬 검증용이며 저장소에 커밋하지 않습니다. API Key를 채팅, 명령행 인수, URL query string, 문서, 로그에 넣지 마세요. hosted proxy 운영용 ASK 서울 전용 서비스 키는 proxy 서버 환경에서만 관리됩니다.
+
+## 이 스킬로 할 수 없는 것
+
+- 기상청 공식 특보를 발령하거나 대체하는 판단
+- 행정동을 좌표·생활권·통칭으로 추정하는 검색
+- 임의의 SQL, 테이블명, 조인, 집계, 정렬 실행
+- 제품이 준비되지 않았을 때 임의의 fixture·synthetic 데이터 반환
+- bundle에 포함되지 않은 다른 제품 조회
+
+## 공식 출처와 추가 문서
+
+- ASK 서울 데이터 상품·게시 상태: [ASK 서울 Marketplace](https://ask-seoul.kr)
+- 공공 데이터 출처 목록: [Sources](../sources.md)
+- 공통 설치: [공통 설치 가이드](../install.md)
+- 보안 및 시크릿 정책: [보안/시크릿 정책](../security-and-secrets.md)
+- proxy 운영자용 route·서비스 키 정책: [k-skill 프록시 서버 가이드](k-skill-proxy.md)
+- 스킬의 상세 실행 계약: [`seoul-weather-risk/instruction.md`](../../seoul-weather-risk/instruction.md)
+
+## 사용 전 체크리스트
+
+- [ ] `preflight`에서 실행 모드를 확인했다.
+- [ ] `catalog`에서 `registration_ready=true`와 빈 `blockers`를 확인했다.
+- [ ] `describe`에서 제품 컬럼과 `forecast_at` 시간축을 확인했다.
+- [ ] 행정동이 모호하면 `--gu`를 지정했다.
+- [ ] 조회 결과의 `publication_id`, `row_count`, `forecast_at`, `risk_labels`를 확인했다.
+- [ ] 공식 특보가 아닌 예보 기반 참고 정보라는 점을 사용자에게 알렸다.
+- [ ] 오류 응답을 성공 데이터나 추정값으로 바꾸지 않았다.

--- a/docs/superpowers/specs/2026-08-12-seoul-weather-risk-fast-path-design.md
+++ b/docs/superpowers/specs/2026-08-12-seoul-weather-risk-fast-path-design.md
@@ -1,0 +1,22 @@
+# seoul-weather-risk fast path 설계
+
+## 목적
+
+일반 사용자의 오늘 기상 위험 질문에서 반복되는 bundle·product metadata 조회를 생략해 hosted proxy 왕복을 줄인다. 등록 전 local-direct나 사용자 API key 경로는 다시 추가하지 않는다.
+
+## 동작
+
+- `query --fast`는 정규 product ID, 행정동 매핑, 자치구 모호성, 날짜 범위, limit, cursor를 로컬에서 검증한다.
+- fast path는 `/v1/ask-seoul/weather-risk/data`만 호출하고 응답 계약(`bundle_id`, `product_id`, `publication_id`, page fields)을 검증한다.
+- `--fast`에서는 metadata가 필요한 임의 `--filter`를 거부한다. 필터나 게시 계약 확인이 필요하면 기존 full-contract query와 `catalog`/`describe` 진단을 사용한다.
+- `product_not_ready`·계약 오류를 fixture나 추정값으로 대체하지 않는다.
+
+## 사용자 흐름
+
+일반 질문은 `query --fast` 한 번으로 처리하고, 오류 또는 readiness 점검 시에만 `preflight → catalog → describe`를 실행한다. 이로써 기본 CLI 실행 수와 live GET 수를 줄이면서 진단 경로와 기존 full-contract 동작은 보존한다.
+
+## 검증
+
+- fast query가 data route만 호출하고 Authorization 헤더를 보내지 않는 회귀 테스트
+- 기존 full-contract query, 행정동 매핑, 오류 계약 테스트 전체 통과
+- source instruction과 CLI 번들·스냅샷 동기화 검사

--- a/packages/k-skill-cli/skills/seoul-weather-risk/instruction.md
+++ b/packages/k-skill-cli/skills/seoul-weather-risk/instruction.md
@@ -2,7 +2,7 @@
 
 ## What this skill does
 
-서울 행정동 이름을 정규 `place_id`로 해석해 ASK 서울의 장소별 기상 위험 예상 시간대 단일 제품(`weather_place_risk_window`)을 읽기 전용으로 탐색한다. 기본 helper는 hosted `k-skill-proxy`를 호출하며, 사용자 API Key를 발급받거나 저장하지 않는다. 등록 전 로컬 검증에는 명시적으로 opt-in한 local-direct 경로를 사용할 수 있다. 실패 또는 미준비 상태를 fixture나 추정값으로 대체하지 않는다.
+서울 행정동 이름을 정규 `place_id`로 해석해 ASK 서울의 장소별 기상 위험 예상 시간대 단일 제품(`weather_place_risk_window`)을 읽기 전용으로 탐색한다. 기본 helper는 hosted `k-skill-proxy`만 호출하며, 사용자 API Key나 현재 작업 폴더의 `.env`를 읽지 않는다. 실패 또는 미준비 상태를 fixture나 추정값으로 대체하지 않는다.
 
 ## Product
 
@@ -67,27 +67,15 @@ npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.p
 
 응답의 `registration_ready`, `publication_id`, `blockers`를 먼저 확인한다. data 응답의 `next_cursor`는 같은 제품의 다음 page에만 그대로 재사용한다. publication이 바뀌면 cursor는 `409`로 만료된다.
 
-## Local pre-registration fallback
-
-hosted proxy가 아직 등록·배포되지 않은 상태에서 로컬 검증이 필요할 때만, **현재 작업 디렉터리**의 `.env`에 다음 세 이름을 설정한다.
-
-```text
-KSKILL_LOCAL_DIRECT=1
-ASK_SEOUL_SKILL_API_BASE_URL=https://ask-seoul.kr
-MARKETPLACE_API_KEY=<기존 로컬 Marketplace 키>
-```
-
-이 opt-in 모드에서는 helper가 `.env`에서 세 이름만 메모리로 읽고 `Authorization: Bearer`로 전달한다. bundle, 단일 `weather_place_risk_window` product, 그 data의 직접 경로 이외에는 호출하지 않는다. 키 값은 명령행 인수·출력·로그·skill 파일에 넣지 않는다. `KSKILL_LOCAL_DIRECT`가 없으면 기존 hosted-proxy 경로를 그대로 사용한다.
-
 ## Boundaries
 
 - table name, SQL, join, sort, aggregate를 입력받지 않는다.
 - 알 수 없는 제품이나 필터를 추측해 보정하지 않는다.
 - 행정동 이름을 fuzzy match하거나 모호한 후보 중 하나로 임의 선택하지 않는다. 생활권·통칭 또는 부분 이름(예: `성수동`)도 행정동으로 추측하지 않는다. helper는 로컬 reference에서 `place_id`를 해석하고 proxy에는 행정동·자치구 문자열을 보내지 않는다.
 - 기본 proxy origin은 `https://k-skill-proxy.nomadamas.org`이다. 별도 self-host proxy를 쓸 때만 `KSKILL_PROXY_BASE_URL`을 HTTPS origin으로 설정한다. 값은 명령행 인수, 문서, 로그에 넣지 않는다.
-- hosted-proxy 모드에서는 사용자 API Key와 `Authorization` 헤더를 사용하지 않는다. ASK Seoul 전용 서비스 키는 proxy 운영 환경에만 두며, Marketplace의 `k-skill-proxy:seoul-weather-risk` principal에 `skill:seoul-weather-risk:read` scope로 등록한다. 이 scope는 bundle·product·data 읽기만 허용하고 다른 Marketplace API를 거부한다. local-direct 모드에서만 현재 작업 폴더 `.env`의 `MARKETPLACE_API_KEY`를 세 direct read 경로에 전달하며, 어떤 모드에서도 키를 출력·로그·skill 파일에 넣지 않는다.
+- hosted-proxy 모드에서는 사용자 API Key와 `Authorization` 헤더를 사용하지 않는다. ASK Seoul 전용 서비스 키는 proxy 운영 환경에만 두며, Marketplace의 `k-skill-proxy:seoul-weather-risk` principal에 `skill:seoul-weather-risk:read` scope로 등록한다. 이 scope는 bundle·product·data 읽기만 허용하고 다른 Marketplace API를 거부한다. 어떤 모드에서도 키를 출력·로그·skill 파일에 넣지 않는다.
 - proxy는 bundle, 단일 product, 그 data 조회만 노출한다. `table name`, SQL, join, sort, aggregate 및 비허용 query field는 upstream으로 전달하지 않는다.
-- `/skill/v1/bundles/seoul-weather-risk`의 제품 집합이 `weather_place_risk_window` 단일 제품과 다르면 응답 계약 오류로 중단한다.
+- `/v1/ask-seoul/weather-risk/bundle`의 제품 집합이 `weather_place_risk_window` 단일 제품과 다르면 응답 계약 오류로 중단한다.
 - live 실패를 fixture나 synthetic 결과로 대체하지 않는다.
 - 이 제품은 예보값 임계치 기반 참고 정보이며 기상청 공식 특보를 대체하지 않는다는 점을 응답에서 명확히 한다.
 
@@ -104,7 +92,6 @@ MARKETPLACE_API_KEY=<기존 로컬 Marketplace 키>
 - `ambiguous_admin_dong`: 동명이거나 별칭 후보가 충돌해 `--gu`가 필요함. `details.candidates`에서 가능한 자치구를 확인한다.
 - `location_mapping_invalid`: bundled 행정동 reference의 버전·스키마·행 수 계약 오류
 - `proxy_disabled`, `invalid_proxy_base_url`: proxy 환경 설정 오류
-- `local_direct_not_configured`, `invalid_local_direct_base_url`: local-direct 환경 설정 오류
 - `unauthorized`/`api_key_missing`(401), `forbidden`/`api_key_forbidden`(403), `unknown_product`(404)
 - `cursor_expired`(409), `rate_limited`(429), `product_not_ready`(503)
 - `upstream_not_configured`(503): proxy 운영 환경에 ASK Seoul 전용 서비스 키 또는 origin이 설정되지 않음

--- a/packages/k-skill-cli/skills/seoul-weather-risk/instruction.md
+++ b/packages/k-skill-cli/skills/seoul-weather-risk/instruction.md
@@ -26,7 +26,34 @@
 
 ## Workflow
 
-1. 환경 설정만 먼저 확인한다. 이 명령은 네트워크를 호출하지 않는다.
+### Standard user query (fast path)
+
+사용자가 오늘 위험 시간대를 묻는 기본 경로는 `query --fast` 한 번만 실행한다. 이 경로는 bundled 행정동 매핑과 날짜·limit 검증을 유지하면서 hosted data route만 한 번 호출하므로 bundle·product metadata 왕복을 생략한다. `--fast`에서는 `--filter`를 사용하지 않고 `--admin-dong`, `--gu`, 날짜, `--limit`, `--cursor`만 사용한다.
+
+```bash
+npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.py -- query --fast \
+  --product-id weather_place_risk_window \
+  --admin-dong 잠실본동 \
+  --from 2026-08-12 \
+  --to 2026-08-12 \
+  --limit 100
+```
+
+동명이명인 `신사동`은 자치구를 확인한 뒤 fast path에도 `--gu`를 함께 전달한다.
+
+```bash
+npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.py -- query --fast \
+  --product-id weather_place_risk_window \
+  --admin-dong 신사동 \
+  --gu 강남구 \
+  --limit 100
+```
+
+`--filter`가 필요하거나 게시 계약을 점검해야 할 때는 `--fast`를 빼고 full-contract query를 사용한다. fast query가 `product_not_ready` 또는 계약 오류를 반환하면 fixture나 추정값으로 대체하지 말고 아래 진단 흐름을 수행한다.
+
+### Contract diagnostics (only when needed)
+
+1. 환경 설정만 확인한다. 이 명령은 네트워크를 호출하지 않는다.
 
 ```bash
 npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.py -- preflight
@@ -44,28 +71,7 @@ npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.p
 npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.py -- describe --product-id weather_place_risk_window
 ```
 
-4. 행정동 이름과 `1..500` 범위의 limit으로 data page를 조회한다.
-
-```bash
-npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.py -- query \
-  --product-id weather_place_risk_window \
-  --admin-dong 잠실본동 \
-  --from 2026-08-01 \
-  --to 2026-08-07 \
-  --limit 100
-```
-
-동명이명인 `신사동`은 자치구를 확인한 뒤 다음처럼 조회한다.
-
-```bash
-npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.py -- query \
-  --product-id weather_place_risk_window \
-  --admin-dong 신사동 \
-  --gu 강남구 \
-  --limit 100
-```
-
-응답의 `registration_ready`, `publication_id`, `blockers`를 먼저 확인한다. data 응답의 `next_cursor`는 같은 제품의 다음 page에만 그대로 재사용한다. publication이 바뀌면 cursor는 `409`로 만료된다.
+진단 응답의 `registration_ready`, `publication_id`, `blockers`를 확인한다. fast/full data 응답의 `next_cursor`는 같은 제품의 다음 page에만 그대로 재사용하며 publication이 바뀌면 cursor는 `409`로 만료된다.
 
 ## Boundaries
 

--- a/packages/k-skill-cli/skills/seoul-weather-risk/scripts/seoul_weather_risk.py
+++ b/packages/k-skill-cli/skills/seoul-weather-risk/scripts/seoul_weather_risk.py
@@ -371,6 +371,7 @@ def _parser() -> argparse.ArgumentParser:
     describe.add_argument("--product-id", required=True)
 
     query = commands.add_parser("query", help="제품 data page 조회")
+    query.add_argument("--fast", action="store_true", help="bundle/product metadata 확인을 생략하고 data만 조회")
     query.add_argument("--product-id", required=True)
     query.add_argument("--filter", action="append", default=[], metavar="COLUMN=VALUE")
     query.add_argument("--admin-dong", help="서울 행정동 이름")
@@ -401,8 +402,12 @@ def run(argv: list[str]) -> int:
         else:
             if not 1 <= args.limit <= 500:
                 raise SkillError("invalid_limit", "limit은 1부터 500 사이여야 합니다.")
-            _bundle(config)
-            detail = _detail(config, args.product_id)
+            if args.fast and args.filter:
+                raise SkillError("fast_query_filter_unsupported", "--fast에서는 --filter를 사용할 수 없습니다.")
+            detail: dict[str, Any] | None = None
+            if not args.fast:
+                _bundle(config)
+                detail = _detail(config, args.product_id)
             filters = _filters(args.filter)
             if args.gu is not None and args.admin_dong is None:
                 raise SkillError("invalid_location_input", "--gu는 --admin-dong과 함께 사용해야 합니다.")
@@ -418,10 +423,11 @@ def run(argv: list[str]) -> int:
                     )
                 resolved = _resolve_admin_dong(args.admin_dong, args.gu)
                 filters["place_id"] = resolved["place_id"]
-            allowed_columns = {column["name"] for column in detail["metadata"].get("columns", [])}
-            unknown = sorted(set(filters) - allowed_columns)
-            if unknown:
-                raise SkillError("unknown_filter", f"공개 projection에 없는 필터입니다: {', '.join(unknown)}")
+            if detail is not None:
+                allowed_columns = {column["name"] for column in detail["metadata"].get("columns", [])}
+                unknown = sorted(set(filters) - allowed_columns)
+                if unknown:
+                    raise SkillError("unknown_filter", f"공개 projection에 없는 필터입니다: {', '.join(unknown)}")
             request_query = {**filters, "limit": str(args.limit)}
             if args.from_value is not None:
                 request_query["from"] = _time_bound(args.from_value, "from")

--- a/packages/k-skill-cli/skills/seoul-weather-risk/scripts/seoul_weather_risk.py
+++ b/packages/k-skill-cli/skills/seoul-weather-risk/scripts/seoul_weather_risk.py
@@ -20,16 +20,7 @@ from urllib.request import HTTPRedirectHandler, Request, build_opener
 SKILL_BUNDLE_ID = "seoul-weather-risk"
 PROXY_BASE_URL_ENV = "KSKILL_PROXY_BASE_URL"
 DEFAULT_PROXY_BASE_URL = "https://k-skill-proxy.nomadamas.org"
-LOCAL_DIRECT_ENV = "KSKILL_LOCAL_DIRECT"
-SKILL_API_BASE_URL_ENV = "ASK_SEOUL_SKILL_API_BASE_URL"
-MARKETPLACE_API_KEY_ENV = "MARKETPLACE_API_KEY"
 PROXY_DISABLED_VALUES = frozenset({"off", "false", "0", "disable", "disabled", "none"})
-LOCAL_DIRECT_ENABLED_VALUES = frozenset({"1", "true", "on", "yes"})
-LOCAL_DIRECT_DOTENV_NAMES = frozenset({
-    LOCAL_DIRECT_ENV,
-    SKILL_API_BASE_URL_ENV,
-    MARKETPLACE_API_KEY_ENV,
-})
 PROXY_ROUTE_ROOT = "/v1/ask-seoul/weather-risk"
 LOCATION_MAPPING_PATH = pathlib.Path(__file__).resolve().parents[1] / "references" / "admin-dong-place-map.json"
 LOCATION_MAPPING_VERSION = "kma_admin_dong_grid_20260325"
@@ -65,54 +56,14 @@ class _NoRedirect(HTTPRedirectHandler):
 @dataclass(frozen=True)
 class ApiConfig:
     base_url: str
-    mode: str = "hosted_proxy"
-    bearer_token: str | None = None
 
 
 def _json(value: Any) -> str:
     return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
 
 
-def _local_direct_config(values: dict[str, str]) -> ApiConfig:
-    base_url = values.get(SKILL_API_BASE_URL_ENV, "").strip()
-    bearer_token = values.get(MARKETPLACE_API_KEY_ENV, "").strip()
-    if not base_url or base_url == "replace-me":
-        raise SkillError("local_direct_not_configured", "local direct API base URL이 필요합니다.")
-    if not bearer_token or bearer_token == "replace-me":
-        raise SkillError("local_direct_not_configured", "local direct Marketplace API key가 필요합니다.")
-
-    parsed = urlparse(base_url)
-    local_http = parsed.scheme == "http" and parsed.hostname in {"127.0.0.1", "localhost", "::1"}
-    if (parsed.scheme != "https" and not local_http) or not parsed.netloc or parsed.path not in {"", "/"} or parsed.query or parsed.fragment:
-        raise SkillError("invalid_local_direct_base_url", "local direct API base URL은 HTTPS origin이어야 합니다.")
-    if parsed.username or parsed.password:
-        raise SkillError("invalid_local_direct_base_url", "local direct API base URL에 사용자 정보는 포함할 수 없습니다.")
-    return ApiConfig(base_url=base_url.rstrip("/"), mode="local_direct", bearer_token=bearer_token)
-
-
-def _current_directory_dotenv() -> dict[str, str]:
-    path = pathlib.Path.cwd() / ".env"
-    try:
-        lines = path.read_text(encoding="utf-8").splitlines()
-    except OSError:
-        return {}
-
-    values: dict[str, str] = {}
-    for line in lines:
-        stripped = line.strip()
-        if not stripped or stripped.startswith("#") or "=" not in stripped:
-            continue
-        name, value = stripped.split("=", 1)
-        name = name.strip()
-        if name in LOCAL_DIRECT_DOTENV_NAMES:
-            values[name] = value.strip().strip('"').strip("'")
-    return values
-
-
 def _api_config(environ: dict[str, str] | None = None) -> ApiConfig:
-    values = ({**_current_directory_dotenv(), **os.environ} if environ is None else environ)
-    if values.get(LOCAL_DIRECT_ENV, "").strip().casefold() in LOCAL_DIRECT_ENABLED_VALUES:
-        return _local_direct_config(values)
+    values = os.environ if environ is None else environ
     configured = values.get(PROXY_BASE_URL_ENV, "").strip()
     if configured.casefold() in PROXY_DISABLED_VALUES:
         raise SkillError("proxy_disabled", f"{PROXY_BASE_URL_ENV}가 비활성화되어 있습니다.")
@@ -159,8 +110,6 @@ def _request_json(config: ApiConfig, path: str, query: dict[str, str] | None = N
         "Accept": "application/json",
         "User-Agent": "k-skill-seoul-weather-risk/1",
     }
-    if config.bearer_token:
-        headers["Authorization"] = f"Bearer {config.bearer_token}"
     request = Request(url, headers=headers)
     try:
         with build_opener(_NoRedirect).open(request, timeout=15) as response:
@@ -399,22 +348,16 @@ def _validate_product_id(product_id: str) -> None:
 
 
 def _bundle(config: ApiConfig) -> dict[str, Any]:
-    if config.mode == "local_direct":
-        return _validate_bundle(_request_json(config, f"/skill/v1/bundles/{SKILL_BUNDLE_ID}"))
     return _validate_bundle(_request_json(config, f"{PROXY_ROUTE_ROOT}/bundle"))
 
 
 def _detail(config: ApiConfig, product_id: str) -> dict[str, Any]:
     _validate_product_id(product_id)
-    if config.mode == "local_direct":
-        return _validate_product(_request_json(config, f"/skill/v1/products/{product_id}"), product_id)
     return _validate_product(_request_json(config, f"{PROXY_ROUTE_ROOT}/product"), product_id)
 
 
 def _data(config: ApiConfig, product_id: str, query: dict[str, str], limit: int) -> dict[str, Any]:
     _validate_product_id(product_id)
-    if config.mode == "local_direct":
-        return _validate_data(_request_json(config, f"/skill/v1/products/{product_id}/data", query), product_id, limit)
     return _validate_data(_request_json(config, f"{PROXY_ROUTE_ROOT}/data", query), product_id, limit)
 
 
@@ -446,11 +389,9 @@ def run(argv: list[str]) -> int:
         if args.command == "preflight":
             result = {
                 "status": "ok",
-                "mode": config.mode,
+                "mode": "hosted_proxy",
                 "live_network": False,
-                "user_api_key_required": config.mode == "local_direct",
-                "proxy_base_url_configured": config.mode == "hosted_proxy",
-                "local_direct_base_url_configured": config.mode == "local_direct",
+                "proxy_base_url_configured": True,
             }
         elif args.command == "catalog":
             result = _bundle(config)

--- a/packages/k-skill-cli/skills/seoul-weather-risk/skill.json
+++ b/packages/k-skill-cli/skills/seoul-weather-risk/skill.json
@@ -1,9 +1,9 @@
 {
   "name": "seoul-weather-risk",
-  "description": "서울 행정동 이름을 정식명 우선·허용된 결정적 표기 별칭만으로 정규 place_id로 해석해 ASK 서울의 장소별 기상 위험 예상 시간대(weather_place_risk_window) 단일 제품을 hosted k-skill proxy에서 읽기 전용 조회한다. 기본 경로에는 사용자 API Key와 place_id 입력이 필요 없으며, 등록 전에는 명시적으로 local-direct 검증을 할 수 있다.",
+  "description": "서울 행정동 이름을 정식명 우선·허용된 결정적 표기 별칭만으로 정규 place_id로 해석해 ASK 서울의 장소별 기상 위험 예상 시간대(weather_place_risk_window) 단일 제품을 hosted k-skill proxy에서 읽기 전용 조회한다. 사용자 API Key와 place_id 입력은 필요하지 않다.",
   "profiles": [
     "proxy",
     "lookup"
   ],
-  "frontmatter": "name: seoul-weather-risk\ndescription: 서울 행정동 이름을 정식명 우선·허용된 결정적 표기 별칭만으로 정규 place_id로 해석해 ASK 서울의 장소별 기상 위험 예상 시간대(weather_place_risk_window) 단일 제품을 hosted k-skill proxy에서 읽기 전용 조회한다. 기본 경로에는 사용자 API Key와 place_id 입력이 필요 없으며, 등록 전에는 명시적으로 local-direct 검증을 할 수 있다.\nlicense: MIT\nmetadata:\n  category: public-data\n  locale: ko-KR\n  phase: live-client"
+  "frontmatter": "name: seoul-weather-risk\ndescription: 서울 행정동 이름을 정식명 우선·허용된 결정적 표기 별칭만으로 정규 place_id로 해석해 ASK 서울의 장소별 기상 위험 예상 시간대(weather_place_risk_window) 단일 제품을 hosted k-skill proxy에서 읽기 전용 조회한다. 사용자 API Key와 place_id 입력은 필요하지 않다.\nlicense: MIT\nmetadata:\n  category: public-data\n  locale: ko-KR\n  phase: live-client"
 }

--- a/packages/k-skill-cli/src/assemble.js
+++ b/packages/k-skill-cli/src/assemble.js
@@ -197,7 +197,7 @@ function rewriteBundledAssetInstructions(raw, skillName) {
 // and `<!-- mode:generic -->` markers. Only the sections matching the detected
 // mode (plus always-sections) are emitted.
 function renderTemplate(raw, mode) {
-  const lines = raw.split("\n");
+  const lines = raw.replace(/\r\n?/g, "\n").split("\n");
   const output = [];
   let current = "always";
 

--- a/packages/k-skill-cli/src/execute.js
+++ b/packages/k-skill-cli/src/execute.js
@@ -10,6 +10,16 @@ function splitShebang(value) {
   return value.trim().split(/\s+/).filter(Boolean);
 }
 
+function resolveShebangCommand(command, env) {
+  const executable = command.split(/[\\/]/).pop().toLowerCase();
+
+  if (executable === "python" || executable === "python3") {
+    return env.KSKILL_PYTHON || (process.platform === "win32" ? "python" : command);
+  }
+
+  return executable === "node" ? process.execPath : command;
+}
+
 function resolveRunner(scriptPath, env = process.env) {
   const firstLine = fs.readFileSync(scriptPath, "utf8").split(/\r?\n/, 1)[0];
 
@@ -20,20 +30,20 @@ function resolveRunner(scriptPath, env = process.env) {
       if (args.length) {
         const [command, ...prefixArgs] = args;
         return {
-          command: command === "node" ? process.execPath : command,
+          command: resolveShebangCommand(command, env),
           args: [...prefixArgs, scriptPath],
         };
       }
     }
 
     if (parts[0]) {
-      return { command: parts[0], args: [...parts.slice(1), scriptPath] };
+      return { command: resolveShebangCommand(parts[0], env), args: [...parts.slice(1), scriptPath] };
     }
   }
 
   switch (path.extname(scriptPath).toLowerCase()) {
     case ".py":
-      return { command: env.KSKILL_PYTHON || "python3", args: [scriptPath] };
+      return { command: env.KSKILL_PYTHON || (process.platform === "win32" ? "python" : "python3"), args: [scriptPath] };
     case ".js":
     case ".cjs":
     case ".mjs":

--- a/packages/k-skill-cli/test/cli.test.js
+++ b/packages/k-skill-cli/test/cli.test.js
@@ -37,6 +37,13 @@ test("renderTemplate emits only always + matching mode sections", () => {
   assert.equal(renderTemplate(raw, "generic"), "- both\n- generic only");
 });
 
+test("renderTemplate treats CRLF mode markers like LF mode markers", () => {
+  const raw = "<!-- mode:always -->\r\n- both\r\n<!-- mode:dolshoi -->\r\n- dolshoi only\r\n<!-- mode:generic -->\r\n- generic only\r\n";
+
+  assert.equal(renderTemplate(raw, "dolshoi"), "- both\n- dolshoi only");
+  assert.equal(renderTemplate(raw, "generic"), "- both\n- generic only");
+});
+
 test("every bundled skill declares only known profiles and assembles in both modes", () => {
   const skills = listSkills();
 
@@ -90,11 +97,15 @@ test("legal skill advances official auth but never bypasses controls", () => {
 });
 
 test("bundledFiles lists helper files for directory-package skills", () => {
-  const files = bundledFiles("kosis-stats");
+  const files = bundledFiles("kosis-stats").map((file) => file.split(path.sep).join("/"));
 
   assert.ok(files.some((f) => f.endsWith("scripts/run_kosis_stats.py")));
   assert.ok(files.some((f) => f.endsWith("references/kosis-openapi-guide.md")));
-  assert.ok(bundledFiles("srt-booking").some((f) => f.endsWith("scripts/srt_booking.py")));
+  assert.ok(
+    bundledFiles("srt-booking")
+      .map((file) => file.split(path.sep).join("/"))
+      .some((f) => f.endsWith("scripts/srt_booking.py")),
+  );
 });
 
 test("all bundled assets are exposed through exec/read/path instructions", () => {
@@ -200,7 +211,7 @@ test("assembled instructions match committed snapshots", () => {
       assert.ok(fs.existsSync(snapshotPath), `missing snapshot ${skillName}.${runtime.mode}.md — run UPDATE_SNAPSHOTS=1 npm test`);
       assert.equal(
         output,
-        fs.readFileSync(snapshotPath, "utf8"),
+        fs.readFileSync(snapshotPath, "utf8").replace(/\r\n?/g, "\n"),
         `${skillName} ${runtime.mode} assembly drifted from its snapshot — review the diff, then run UPDATE_SNAPSHOTS=1 npm test`,
       );
     }

--- a/packages/k-skill-cli/test/cli.test.js
+++ b/packages/k-skill-cli/test/cli.test.js
@@ -172,6 +172,16 @@ test("runner selection honors shebangs and executes bundled Node helpers", () =>
   assert.equal(JSON.parse(result.stdout).counts.characters, 3);
 });
 
+test("runner selection lets KSKILL_PYTHON override Python shebangs", () => {
+  const pythonScript = resolveBundledAsset("seoul-weather-risk", "scripts/seoul_weather_risk.py");
+  const defaultRunner = resolveRunner(pythonScript);
+  const runner = resolveRunner(pythonScript, { KSKILL_PYTHON: "python-custom" });
+
+  assert.equal(defaultRunner.command, process.platform === "win32" ? "python" : "python3");
+  assert.equal(runner.command, "python-custom");
+  assert.deepEqual(runner.args, [pythonScript]);
+});
+
 test("assembled instructions match committed snapshots", () => {
   const snapshotDir = path.join(__dirname, "snapshots");
   const update = process.env.UPDATE_SNAPSHOTS === "1";

--- a/packages/k-skill-cli/test/snapshots/seoul-weather-risk.dolshoi.md
+++ b/packages/k-skill-cli/test/snapshots/seoul-weather-risk.dolshoi.md
@@ -48,7 +48,34 @@ Runtime mode: dolshoi (CloakBrowser available)
 
 ## Workflow
 
-1. 환경 설정만 먼저 확인한다. 이 명령은 네트워크를 호출하지 않는다.
+### Standard user query (fast path)
+
+사용자가 오늘 위험 시간대를 묻는 기본 경로는 `query --fast` 한 번만 실행한다. 이 경로는 bundled 행정동 매핑과 날짜·limit 검증을 유지하면서 hosted data route만 한 번 호출하므로 bundle·product metadata 왕복을 생략한다. `--fast`에서는 `--filter`를 사용하지 않고 `--admin-dong`, `--gu`, 날짜, `--limit`, `--cursor`만 사용한다.
+
+```bash
+npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.py -- query --fast \
+  --product-id weather_place_risk_window \
+  --admin-dong 잠실본동 \
+  --from 2026-08-12 \
+  --to 2026-08-12 \
+  --limit 100
+```
+
+동명이명인 `신사동`은 자치구를 확인한 뒤 fast path에도 `--gu`를 함께 전달한다.
+
+```bash
+npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.py -- query --fast \
+  --product-id weather_place_risk_window \
+  --admin-dong 신사동 \
+  --gu 강남구 \
+  --limit 100
+```
+
+`--filter`가 필요하거나 게시 계약을 점검해야 할 때는 `--fast`를 빼고 full-contract query를 사용한다. fast query가 `product_not_ready` 또는 계약 오류를 반환하면 fixture나 추정값으로 대체하지 말고 아래 진단 흐름을 수행한다.
+
+### Contract diagnostics (only when needed)
+
+1. 환경 설정만 확인한다. 이 명령은 네트워크를 호출하지 않는다.
 
 ```bash
 npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.py -- preflight
@@ -66,28 +93,7 @@ npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.p
 npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.py -- describe --product-id weather_place_risk_window
 ```
 
-4. 행정동 이름과 `1..500` 범위의 limit으로 data page를 조회한다.
-
-```bash
-npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.py -- query \
-  --product-id weather_place_risk_window \
-  --admin-dong 잠실본동 \
-  --from 2026-08-01 \
-  --to 2026-08-07 \
-  --limit 100
-```
-
-동명이명인 `신사동`은 자치구를 확인한 뒤 다음처럼 조회한다.
-
-```bash
-npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.py -- query \
-  --product-id weather_place_risk_window \
-  --admin-dong 신사동 \
-  --gu 강남구 \
-  --limit 100
-```
-
-응답의 `registration_ready`, `publication_id`, `blockers`를 먼저 확인한다. data 응답의 `next_cursor`는 같은 제품의 다음 page에만 그대로 재사용한다. publication이 바뀌면 cursor는 `409`로 만료된다.
+진단 응답의 `registration_ready`, `publication_id`, `blockers`를 확인한다. fast/full data 응답의 `next_cursor`는 같은 제품의 다음 page에만 그대로 재사용하며 publication이 바뀌면 cursor는 `409`로 만료된다.
 
 ## Boundaries
 

--- a/packages/k-skill-cli/test/snapshots/seoul-weather-risk.dolshoi.md
+++ b/packages/k-skill-cli/test/snapshots/seoul-weather-risk.dolshoi.md
@@ -4,11 +4,14 @@ Runtime mode: dolshoi (CloakBrowser available)
 
 ## Runtime rules
 
+<!-- mode:always -->
 - Detect capabilities, not product names. Dolshoi credential mode is active only when `DOLSHOI_ACTION_BROKER_URL` is set and `vault-run` is available; CloakBrowser mode is active when the built-in browser tool identifies CloakBrowser or `CLOAKBROWSER_PEEK_TOKEN` is set.
 - When the user asks for an action and the official surface supports it lawfully, continue beyond lookup through reversible preparation and execution. Do not declare completion at a result list, deep link, or handoff when the action can still be carried out.
 - Immediately before an irreversible external side effect such as payment, message/email delivery, final submission, cancellation, account mutation, or public posting, call `clarify` with the exact target, amount/payload, and effect. Execute only after approval; do not ask again for already-approved reversible steps.
 - Preserve hard boundaries for law, required physical presence, CAPTCHA, identity proofing, electronic signatures, and unsupported official surfaces. In those cases, complete the furthest lawful supported step and open or prepare the exact next official step for the user.
+<!-- mode:always -->
 - Plain lookups go through the hosted `k-skill-proxy` (`https://k-skill-proxy.nomadamas.org`) by default; no user API key is needed. Set `KSKILL_PROXY_BASE_URL` only for a self-hosted or alternate proxy. Direct upstream calls require the skill-documented API key.
+<!-- mode:always -->
 - This skill is lookup-oriented. Completion means the requested data is retrieved, summarized with its source (table/endpoint, period, unit), and any requested follow-up action is connected to the official surface that supports it.
 
 ## Bundled asset access
@@ -21,7 +24,7 @@ Runtime mode: dolshoi (CloakBrowser available)
 
 ## What this skill does
 
-서울 행정동 이름을 정규 `place_id`로 해석해 ASK 서울의 장소별 기상 위험 예상 시간대 단일 제품(`weather_place_risk_window`)을 읽기 전용으로 탐색한다. 기본 helper는 hosted `k-skill-proxy`를 호출하며, 사용자 API Key를 발급받거나 저장하지 않는다. 등록 전 로컬 검증에는 명시적으로 opt-in한 local-direct 경로를 사용할 수 있다. 실패 또는 미준비 상태를 fixture나 추정값으로 대체하지 않는다.
+서울 행정동 이름을 정규 `place_id`로 해석해 ASK 서울의 장소별 기상 위험 예상 시간대 단일 제품(`weather_place_risk_window`)을 읽기 전용으로 탐색한다. 기본 helper는 hosted `k-skill-proxy`만 호출하며, 사용자 API Key나 현재 작업 폴더의 `.env`를 읽지 않는다. 실패 또는 미준비 상태를 fixture나 추정값으로 대체하지 않는다.
 
 ## Product
 
@@ -86,27 +89,15 @@ npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.p
 
 응답의 `registration_ready`, `publication_id`, `blockers`를 먼저 확인한다. data 응답의 `next_cursor`는 같은 제품의 다음 page에만 그대로 재사용한다. publication이 바뀌면 cursor는 `409`로 만료된다.
 
-## Local pre-registration fallback
-
-hosted proxy가 아직 등록·배포되지 않은 상태에서 로컬 검증이 필요할 때만, **현재 작업 디렉터리**의 `.env`에 다음 세 이름을 설정한다.
-
-```text
-KSKILL_LOCAL_DIRECT=1
-ASK_SEOUL_SKILL_API_BASE_URL=https://ask-seoul.kr
-MARKETPLACE_API_KEY=<기존 로컬 Marketplace 키>
-```
-
-이 opt-in 모드에서는 helper가 `.env`에서 세 이름만 메모리로 읽고 `Authorization: Bearer`로 전달한다. bundle, 단일 `weather_place_risk_window` product, 그 data의 직접 경로 이외에는 호출하지 않는다. 키 값은 명령행 인수·출력·로그·skill 파일에 넣지 않는다. `KSKILL_LOCAL_DIRECT`가 없으면 기존 hosted-proxy 경로를 그대로 사용한다.
-
 ## Boundaries
 
 - table name, SQL, join, sort, aggregate를 입력받지 않는다.
 - 알 수 없는 제품이나 필터를 추측해 보정하지 않는다.
 - 행정동 이름을 fuzzy match하거나 모호한 후보 중 하나로 임의 선택하지 않는다. 생활권·통칭 또는 부분 이름(예: `성수동`)도 행정동으로 추측하지 않는다. helper는 로컬 reference에서 `place_id`를 해석하고 proxy에는 행정동·자치구 문자열을 보내지 않는다.
 - 기본 proxy origin은 `https://k-skill-proxy.nomadamas.org`이다. 별도 self-host proxy를 쓸 때만 `KSKILL_PROXY_BASE_URL`을 HTTPS origin으로 설정한다. 값은 명령행 인수, 문서, 로그에 넣지 않는다.
-- hosted-proxy 모드에서는 사용자 API Key와 `Authorization` 헤더를 사용하지 않는다. ASK Seoul 전용 서비스 키는 proxy 운영 환경에만 두며, Marketplace의 `k-skill-proxy:seoul-weather-risk` principal에 `skill:seoul-weather-risk:read` scope로 등록한다. 이 scope는 bundle·product·data 읽기만 허용하고 다른 Marketplace API를 거부한다. local-direct 모드에서만 현재 작업 폴더 `.env`의 `MARKETPLACE_API_KEY`를 세 direct read 경로에 전달하며, 어떤 모드에서도 키를 출력·로그·skill 파일에 넣지 않는다.
+- hosted-proxy 모드에서는 사용자 API Key와 `Authorization` 헤더를 사용하지 않는다. ASK Seoul 전용 서비스 키는 proxy 운영 환경에만 두며, Marketplace의 `k-skill-proxy:seoul-weather-risk` principal에 `skill:seoul-weather-risk:read` scope로 등록한다. 이 scope는 bundle·product·data 읽기만 허용하고 다른 Marketplace API를 거부한다. 어떤 모드에서도 키를 출력·로그·skill 파일에 넣지 않는다.
 - proxy는 bundle, 단일 product, 그 data 조회만 노출한다. `table name`, SQL, join, sort, aggregate 및 비허용 query field는 upstream으로 전달하지 않는다.
-- `/skill/v1/bundles/seoul-weather-risk`의 제품 집합이 `weather_place_risk_window` 단일 제품과 다르면 응답 계약 오류로 중단한다.
+- `/v1/ask-seoul/weather-risk/bundle`의 제품 집합이 `weather_place_risk_window` 단일 제품과 다르면 응답 계약 오류로 중단한다.
 - live 실패를 fixture나 synthetic 결과로 대체하지 않는다.
 - 이 제품은 예보값 임계치 기반 참고 정보이며 기상청 공식 특보를 대체하지 않는다는 점을 응답에서 명확히 한다.
 
@@ -123,7 +114,6 @@ MARKETPLACE_API_KEY=<기존 로컬 Marketplace 키>
 - `ambiguous_admin_dong`: 동명이거나 별칭 후보가 충돌해 `--gu`가 필요함. `details.candidates`에서 가능한 자치구를 확인한다.
 - `location_mapping_invalid`: bundled 행정동 reference의 버전·스키마·행 수 계약 오류
 - `proxy_disabled`, `invalid_proxy_base_url`: proxy 환경 설정 오류
-- `local_direct_not_configured`, `invalid_local_direct_base_url`: local-direct 환경 설정 오류
 - `unauthorized`/`api_key_missing`(401), `forbidden`/`api_key_forbidden`(403), `unknown_product`(404)
 - `cursor_expired`(409), `rate_limited`(429), `product_not_ready`(503)
 - `upstream_not_configured`(503): proxy 운영 환경에 ASK Seoul 전용 서비스 키 또는 origin이 설정되지 않음

--- a/packages/k-skill-cli/test/snapshots/seoul-weather-risk.dolshoi.md
+++ b/packages/k-skill-cli/test/snapshots/seoul-weather-risk.dolshoi.md
@@ -4,14 +4,11 @@ Runtime mode: dolshoi (CloakBrowser available)
 
 ## Runtime rules
 
-<!-- mode:always -->
 - Detect capabilities, not product names. Dolshoi credential mode is active only when `DOLSHOI_ACTION_BROKER_URL` is set and `vault-run` is available; CloakBrowser mode is active when the built-in browser tool identifies CloakBrowser or `CLOAKBROWSER_PEEK_TOKEN` is set.
 - When the user asks for an action and the official surface supports it lawfully, continue beyond lookup through reversible preparation and execution. Do not declare completion at a result list, deep link, or handoff when the action can still be carried out.
 - Immediately before an irreversible external side effect such as payment, message/email delivery, final submission, cancellation, account mutation, or public posting, call `clarify` with the exact target, amount/payload, and effect. Execute only after approval; do not ask again for already-approved reversible steps.
 - Preserve hard boundaries for law, required physical presence, CAPTCHA, identity proofing, electronic signatures, and unsupported official surfaces. In those cases, complete the furthest lawful supported step and open or prepare the exact next official step for the user.
-<!-- mode:always -->
 - Plain lookups go through the hosted `k-skill-proxy` (`https://k-skill-proxy.nomadamas.org`) by default; no user API key is needed. Set `KSKILL_PROXY_BASE_URL` only for a self-hosted or alternate proxy. Direct upstream calls require the skill-documented API key.
-<!-- mode:always -->
 - This skill is lookup-oriented. Completion means the requested data is retrieved, summarized with its source (table/endpoint, period, unit), and any requested follow-up action is connected to the official surface that supports it.
 
 ## Bundled asset access

--- a/packages/k-skill-cli/test/snapshots/seoul-weather-risk.generic.md
+++ b/packages/k-skill-cli/test/snapshots/seoul-weather-risk.generic.md
@@ -4,14 +4,11 @@ Runtime mode: generic
 
 ## Runtime rules
 
-<!-- mode:always -->
 - Detect capabilities, not product names. Dolshoi credential mode is active only when `DOLSHOI_ACTION_BROKER_URL` is set and `vault-run` is available; CloakBrowser mode is active when the built-in browser tool identifies CloakBrowser or `CLOAKBROWSER_PEEK_TOKEN` is set.
 - When the user asks for an action and the official surface supports it lawfully, continue beyond lookup through reversible preparation and execution. Do not declare completion at a result list, deep link, or handoff when the action can still be carried out.
 - Immediately before an irreversible external side effect such as payment, message/email delivery, final submission, cancellation, account mutation, or public posting, call `clarify` with the exact target, amount/payload, and effect. Execute only after approval; do not ask again for already-approved reversible steps.
 - Preserve hard boundaries for law, required physical presence, CAPTCHA, identity proofing, electronic signatures, and unsupported official surfaces. In those cases, complete the furthest lawful supported step and open or prepare the exact next official step for the user.
-<!-- mode:always -->
 - Plain lookups go through the hosted `k-skill-proxy` (`https://k-skill-proxy.nomadamas.org`) by default; no user API key is needed. Set `KSKILL_PROXY_BASE_URL` only for a self-hosted or alternate proxy. Direct upstream calls require the skill-documented API key.
-<!-- mode:always -->
 - This skill is lookup-oriented. Completion means the requested data is retrieved, summarized with its source (table/endpoint, period, unit), and any requested follow-up action is connected to the official surface that supports it.
 
 ## Bundled asset access

--- a/packages/k-skill-cli/test/snapshots/seoul-weather-risk.generic.md
+++ b/packages/k-skill-cli/test/snapshots/seoul-weather-risk.generic.md
@@ -48,7 +48,34 @@ Runtime mode: generic
 
 ## Workflow
 
-1. 환경 설정만 먼저 확인한다. 이 명령은 네트워크를 호출하지 않는다.
+### Standard user query (fast path)
+
+사용자가 오늘 위험 시간대를 묻는 기본 경로는 `query --fast` 한 번만 실행한다. 이 경로는 bundled 행정동 매핑과 날짜·limit 검증을 유지하면서 hosted data route만 한 번 호출하므로 bundle·product metadata 왕복을 생략한다. `--fast`에서는 `--filter`를 사용하지 않고 `--admin-dong`, `--gu`, 날짜, `--limit`, `--cursor`만 사용한다.
+
+```bash
+npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.py -- query --fast \
+  --product-id weather_place_risk_window \
+  --admin-dong 잠실본동 \
+  --from 2026-08-12 \
+  --to 2026-08-12 \
+  --limit 100
+```
+
+동명이명인 `신사동`은 자치구를 확인한 뒤 fast path에도 `--gu`를 함께 전달한다.
+
+```bash
+npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.py -- query --fast \
+  --product-id weather_place_risk_window \
+  --admin-dong 신사동 \
+  --gu 강남구 \
+  --limit 100
+```
+
+`--filter`가 필요하거나 게시 계약을 점검해야 할 때는 `--fast`를 빼고 full-contract query를 사용한다. fast query가 `product_not_ready` 또는 계약 오류를 반환하면 fixture나 추정값으로 대체하지 말고 아래 진단 흐름을 수행한다.
+
+### Contract diagnostics (only when needed)
+
+1. 환경 설정만 확인한다. 이 명령은 네트워크를 호출하지 않는다.
 
 ```bash
 npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.py -- preflight
@@ -66,28 +93,7 @@ npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.p
 npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.py -- describe --product-id weather_place_risk_window
 ```
 
-4. 행정동 이름과 `1..500` 범위의 limit으로 data page를 조회한다.
-
-```bash
-npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.py -- query \
-  --product-id weather_place_risk_window \
-  --admin-dong 잠실본동 \
-  --from 2026-08-01 \
-  --to 2026-08-07 \
-  --limit 100
-```
-
-동명이명인 `신사동`은 자치구를 확인한 뒤 다음처럼 조회한다.
-
-```bash
-npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.py -- query \
-  --product-id weather_place_risk_window \
-  --admin-dong 신사동 \
-  --gu 강남구 \
-  --limit 100
-```
-
-응답의 `registration_ready`, `publication_id`, `blockers`를 먼저 확인한다. data 응답의 `next_cursor`는 같은 제품의 다음 page에만 그대로 재사용한다. publication이 바뀌면 cursor는 `409`로 만료된다.
+진단 응답의 `registration_ready`, `publication_id`, `blockers`를 확인한다. fast/full data 응답의 `next_cursor`는 같은 제품의 다음 page에만 그대로 재사용하며 publication이 바뀌면 cursor는 `409`로 만료된다.
 
 ## Boundaries
 

--- a/packages/k-skill-cli/test/snapshots/seoul-weather-risk.generic.md
+++ b/packages/k-skill-cli/test/snapshots/seoul-weather-risk.generic.md
@@ -4,11 +4,14 @@ Runtime mode: generic
 
 ## Runtime rules
 
+<!-- mode:always -->
 - Detect capabilities, not product names. Dolshoi credential mode is active only when `DOLSHOI_ACTION_BROKER_URL` is set and `vault-run` is available; CloakBrowser mode is active when the built-in browser tool identifies CloakBrowser or `CLOAKBROWSER_PEEK_TOKEN` is set.
 - When the user asks for an action and the official surface supports it lawfully, continue beyond lookup through reversible preparation and execution. Do not declare completion at a result list, deep link, or handoff when the action can still be carried out.
 - Immediately before an irreversible external side effect such as payment, message/email delivery, final submission, cancellation, account mutation, or public posting, call `clarify` with the exact target, amount/payload, and effect. Execute only after approval; do not ask again for already-approved reversible steps.
 - Preserve hard boundaries for law, required physical presence, CAPTCHA, identity proofing, electronic signatures, and unsupported official surfaces. In those cases, complete the furthest lawful supported step and open or prepare the exact next official step for the user.
+<!-- mode:always -->
 - Plain lookups go through the hosted `k-skill-proxy` (`https://k-skill-proxy.nomadamas.org`) by default; no user API key is needed. Set `KSKILL_PROXY_BASE_URL` only for a self-hosted or alternate proxy. Direct upstream calls require the skill-documented API key.
+<!-- mode:always -->
 - This skill is lookup-oriented. Completion means the requested data is retrieved, summarized with its source (table/endpoint, period, unit), and any requested follow-up action is connected to the official surface that supports it.
 
 ## Bundled asset access
@@ -21,7 +24,7 @@ Runtime mode: generic
 
 ## What this skill does
 
-서울 행정동 이름을 정규 `place_id`로 해석해 ASK 서울의 장소별 기상 위험 예상 시간대 단일 제품(`weather_place_risk_window`)을 읽기 전용으로 탐색한다. 기본 helper는 hosted `k-skill-proxy`를 호출하며, 사용자 API Key를 발급받거나 저장하지 않는다. 등록 전 로컬 검증에는 명시적으로 opt-in한 local-direct 경로를 사용할 수 있다. 실패 또는 미준비 상태를 fixture나 추정값으로 대체하지 않는다.
+서울 행정동 이름을 정규 `place_id`로 해석해 ASK 서울의 장소별 기상 위험 예상 시간대 단일 제품(`weather_place_risk_window`)을 읽기 전용으로 탐색한다. 기본 helper는 hosted `k-skill-proxy`만 호출하며, 사용자 API Key나 현재 작업 폴더의 `.env`를 읽지 않는다. 실패 또는 미준비 상태를 fixture나 추정값으로 대체하지 않는다.
 
 ## Product
 
@@ -86,27 +89,15 @@ npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.p
 
 응답의 `registration_ready`, `publication_id`, `blockers`를 먼저 확인한다. data 응답의 `next_cursor`는 같은 제품의 다음 page에만 그대로 재사용한다. publication이 바뀌면 cursor는 `409`로 만료된다.
 
-## Local pre-registration fallback
-
-hosted proxy가 아직 등록·배포되지 않은 상태에서 로컬 검증이 필요할 때만, **현재 작업 디렉터리**의 `.env`에 다음 세 이름을 설정한다.
-
-```text
-KSKILL_LOCAL_DIRECT=1
-ASK_SEOUL_SKILL_API_BASE_URL=https://ask-seoul.kr
-MARKETPLACE_API_KEY=<기존 로컬 Marketplace 키>
-```
-
-이 opt-in 모드에서는 helper가 `.env`에서 세 이름만 메모리로 읽고 `Authorization: Bearer`로 전달한다. bundle, 단일 `weather_place_risk_window` product, 그 data의 직접 경로 이외에는 호출하지 않는다. 키 값은 명령행 인수·출력·로그·skill 파일에 넣지 않는다. `KSKILL_LOCAL_DIRECT`가 없으면 기존 hosted-proxy 경로를 그대로 사용한다.
-
 ## Boundaries
 
 - table name, SQL, join, sort, aggregate를 입력받지 않는다.
 - 알 수 없는 제품이나 필터를 추측해 보정하지 않는다.
 - 행정동 이름을 fuzzy match하거나 모호한 후보 중 하나로 임의 선택하지 않는다. 생활권·통칭 또는 부분 이름(예: `성수동`)도 행정동으로 추측하지 않는다. helper는 로컬 reference에서 `place_id`를 해석하고 proxy에는 행정동·자치구 문자열을 보내지 않는다.
 - 기본 proxy origin은 `https://k-skill-proxy.nomadamas.org`이다. 별도 self-host proxy를 쓸 때만 `KSKILL_PROXY_BASE_URL`을 HTTPS origin으로 설정한다. 값은 명령행 인수, 문서, 로그에 넣지 않는다.
-- hosted-proxy 모드에서는 사용자 API Key와 `Authorization` 헤더를 사용하지 않는다. ASK Seoul 전용 서비스 키는 proxy 운영 환경에만 두며, Marketplace의 `k-skill-proxy:seoul-weather-risk` principal에 `skill:seoul-weather-risk:read` scope로 등록한다. 이 scope는 bundle·product·data 읽기만 허용하고 다른 Marketplace API를 거부한다. local-direct 모드에서만 현재 작업 폴더 `.env`의 `MARKETPLACE_API_KEY`를 세 direct read 경로에 전달하며, 어떤 모드에서도 키를 출력·로그·skill 파일에 넣지 않는다.
+- hosted-proxy 모드에서는 사용자 API Key와 `Authorization` 헤더를 사용하지 않는다. ASK Seoul 전용 서비스 키는 proxy 운영 환경에만 두며, Marketplace의 `k-skill-proxy:seoul-weather-risk` principal에 `skill:seoul-weather-risk:read` scope로 등록한다. 이 scope는 bundle·product·data 읽기만 허용하고 다른 Marketplace API를 거부한다. 어떤 모드에서도 키를 출력·로그·skill 파일에 넣지 않는다.
 - proxy는 bundle, 단일 product, 그 data 조회만 노출한다. `table name`, SQL, join, sort, aggregate 및 비허용 query field는 upstream으로 전달하지 않는다.
-- `/skill/v1/bundles/seoul-weather-risk`의 제품 집합이 `weather_place_risk_window` 단일 제품과 다르면 응답 계약 오류로 중단한다.
+- `/v1/ask-seoul/weather-risk/bundle`의 제품 집합이 `weather_place_risk_window` 단일 제품과 다르면 응답 계약 오류로 중단한다.
 - live 실패를 fixture나 synthetic 결과로 대체하지 않는다.
 - 이 제품은 예보값 임계치 기반 참고 정보이며 기상청 공식 특보를 대체하지 않는다는 점을 응답에서 명확히 한다.
 
@@ -123,7 +114,6 @@ MARKETPLACE_API_KEY=<기존 로컬 Marketplace 키>
 - `ambiguous_admin_dong`: 동명이거나 별칭 후보가 충돌해 `--gu`가 필요함. `details.candidates`에서 가능한 자치구를 확인한다.
 - `location_mapping_invalid`: bundled 행정동 reference의 버전·스키마·행 수 계약 오류
 - `proxy_disabled`, `invalid_proxy_base_url`: proxy 환경 설정 오류
-- `local_direct_not_configured`, `invalid_local_direct_base_url`: local-direct 환경 설정 오류
 - `unauthorized`/`api_key_missing`(401), `forbidden`/`api_key_forbidden`(403), `unknown_product`(404)
 - `cursor_expired`(409), `rate_limited`(429), `product_not_ready`(503)
 - `upstream_not_configured`(503): proxy 운영 환경에 ASK Seoul 전용 서비스 키 또는 origin이 설정되지 않음

--- a/seoul-weather-risk/SKILL.md
+++ b/seoul-weather-risk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: seoul-weather-risk
-description: 서울 행정동 이름을 정식명 우선·허용된 결정적 표기 별칭만으로 정규 place_id로 해석해 ASK 서울의 장소별 기상 위험 예상 시간대(weather_place_risk_window) 단일 제품을 hosted k-skill proxy에서 읽기 전용 조회한다. 기본 경로에는 사용자 API Key와 place_id 입력이 필요 없으며, 등록 전에는 명시적으로 local-direct 검증을 할 수 있다.
+description: 서울 행정동 이름을 정식명 우선·허용된 결정적 표기 별칭만으로 정규 place_id로 해석해 ASK 서울의 장소별 기상 위험 예상 시간대(weather_place_risk_window) 단일 제품을 hosted k-skill proxy에서 읽기 전용 조회한다. 사용자 API Key와 place_id 입력은 필요하지 않다.
 license: MIT
 metadata:
   category: public-data

--- a/seoul-weather-risk/instruction.md
+++ b/seoul-weather-risk/instruction.md
@@ -2,7 +2,7 @@
 
 ## What this skill does
 
-서울 행정동 이름을 정규 `place_id`로 해석해 ASK 서울의 장소별 기상 위험 예상 시간대 단일 제품(`weather_place_risk_window`)을 읽기 전용으로 탐색한다. 기본 helper는 hosted `k-skill-proxy`를 호출하며, 사용자 API Key를 발급받거나 저장하지 않는다. 등록 전 로컬 검증에는 명시적으로 opt-in한 local-direct 경로를 사용할 수 있다. 실패 또는 미준비 상태를 fixture나 추정값으로 대체하지 않는다.
+서울 행정동 이름을 정규 `place_id`로 해석해 ASK 서울의 장소별 기상 위험 예상 시간대 단일 제품(`weather_place_risk_window`)을 읽기 전용으로 탐색한다. 기본 helper는 hosted `k-skill-proxy`만 호출하며, 사용자 API Key나 현재 작업 폴더의 `.env`를 읽지 않는다. 실패 또는 미준비 상태를 fixture나 추정값으로 대체하지 않는다.
 
 ## Product
 
@@ -67,27 +67,15 @@ npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.p
 
 응답의 `registration_ready`, `publication_id`, `blockers`를 먼저 확인한다. data 응답의 `next_cursor`는 같은 제품의 다음 page에만 그대로 재사용한다. publication이 바뀌면 cursor는 `409`로 만료된다.
 
-## Local pre-registration fallback
-
-hosted proxy가 아직 등록·배포되지 않은 상태에서 로컬 검증이 필요할 때만, **현재 작업 디렉터리**의 `.env`에 다음 세 이름을 설정한다.
-
-```text
-KSKILL_LOCAL_DIRECT=1
-ASK_SEOUL_SKILL_API_BASE_URL=https://ask-seoul.kr
-MARKETPLACE_API_KEY=<기존 로컬 Marketplace 키>
-```
-
-이 opt-in 모드에서는 helper가 `.env`에서 세 이름만 메모리로 읽고 `Authorization: Bearer`로 전달한다. bundle, 단일 `weather_place_risk_window` product, 그 data의 직접 경로 이외에는 호출하지 않는다. 키 값은 명령행 인수·출력·로그·skill 파일에 넣지 않는다. `KSKILL_LOCAL_DIRECT`가 없으면 기존 hosted-proxy 경로를 그대로 사용한다.
-
 ## Boundaries
 
 - table name, SQL, join, sort, aggregate를 입력받지 않는다.
 - 알 수 없는 제품이나 필터를 추측해 보정하지 않는다.
 - 행정동 이름을 fuzzy match하거나 모호한 후보 중 하나로 임의 선택하지 않는다. 생활권·통칭 또는 부분 이름(예: `성수동`)도 행정동으로 추측하지 않는다. helper는 로컬 reference에서 `place_id`를 해석하고 proxy에는 행정동·자치구 문자열을 보내지 않는다.
 - 기본 proxy origin은 `https://k-skill-proxy.nomadamas.org`이다. 별도 self-host proxy를 쓸 때만 `KSKILL_PROXY_BASE_URL`을 HTTPS origin으로 설정한다. 값은 명령행 인수, 문서, 로그에 넣지 않는다.
-- hosted-proxy 모드에서는 사용자 API Key와 `Authorization` 헤더를 사용하지 않는다. ASK Seoul 전용 서비스 키는 proxy 운영 환경에만 두며, Marketplace의 `k-skill-proxy:seoul-weather-risk` principal에 `skill:seoul-weather-risk:read` scope로 등록한다. 이 scope는 bundle·product·data 읽기만 허용하고 다른 Marketplace API를 거부한다. local-direct 모드에서만 현재 작업 폴더 `.env`의 `MARKETPLACE_API_KEY`를 세 direct read 경로에 전달하며, 어떤 모드에서도 키를 출력·로그·skill 파일에 넣지 않는다.
+- hosted-proxy 모드에서는 사용자 API Key와 `Authorization` 헤더를 사용하지 않는다. ASK Seoul 전용 서비스 키는 proxy 운영 환경에만 두며, Marketplace의 `k-skill-proxy:seoul-weather-risk` principal에 `skill:seoul-weather-risk:read` scope로 등록한다. 이 scope는 bundle·product·data 읽기만 허용하고 다른 Marketplace API를 거부한다. 어떤 모드에서도 키를 출력·로그·skill 파일에 넣지 않는다.
 - proxy는 bundle, 단일 product, 그 data 조회만 노출한다. `table name`, SQL, join, sort, aggregate 및 비허용 query field는 upstream으로 전달하지 않는다.
-- `/skill/v1/bundles/seoul-weather-risk`의 제품 집합이 `weather_place_risk_window` 단일 제품과 다르면 응답 계약 오류로 중단한다.
+- `/v1/ask-seoul/weather-risk/bundle`의 제품 집합이 `weather_place_risk_window` 단일 제품과 다르면 응답 계약 오류로 중단한다.
 - live 실패를 fixture나 synthetic 결과로 대체하지 않는다.
 - 이 제품은 예보값 임계치 기반 참고 정보이며 기상청 공식 특보를 대체하지 않는다는 점을 응답에서 명확히 한다.
 
@@ -104,7 +92,6 @@ MARKETPLACE_API_KEY=<기존 로컬 Marketplace 키>
 - `ambiguous_admin_dong`: 동명이거나 별칭 후보가 충돌해 `--gu`가 필요함. `details.candidates`에서 가능한 자치구를 확인한다.
 - `location_mapping_invalid`: bundled 행정동 reference의 버전·스키마·행 수 계약 오류
 - `proxy_disabled`, `invalid_proxy_base_url`: proxy 환경 설정 오류
-- `local_direct_not_configured`, `invalid_local_direct_base_url`: local-direct 환경 설정 오류
 - `unauthorized`/`api_key_missing`(401), `forbidden`/`api_key_forbidden`(403), `unknown_product`(404)
 - `cursor_expired`(409), `rate_limited`(429), `product_not_ready`(503)
 - `upstream_not_configured`(503): proxy 운영 환경에 ASK Seoul 전용 서비스 키 또는 origin이 설정되지 않음

--- a/seoul-weather-risk/instruction.md
+++ b/seoul-weather-risk/instruction.md
@@ -26,7 +26,34 @@
 
 ## Workflow
 
-1. 환경 설정만 먼저 확인한다. 이 명령은 네트워크를 호출하지 않는다.
+### Standard user query (fast path)
+
+사용자가 오늘 위험 시간대를 묻는 기본 경로는 `query --fast` 한 번만 실행한다. 이 경로는 bundled 행정동 매핑과 날짜·limit 검증을 유지하면서 hosted data route만 한 번 호출하므로 bundle·product metadata 왕복을 생략한다. `--fast`에서는 `--filter`를 사용하지 않고 `--admin-dong`, `--gu`, 날짜, `--limit`, `--cursor`만 사용한다.
+
+```bash
+npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.py -- query --fast \
+  --product-id weather_place_risk_window \
+  --admin-dong 잠실본동 \
+  --from 2026-08-12 \
+  --to 2026-08-12 \
+  --limit 100
+```
+
+동명이명인 `신사동`은 자치구를 확인한 뒤 fast path에도 `--gu`를 함께 전달한다.
+
+```bash
+npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.py -- query --fast \
+  --product-id weather_place_risk_window \
+  --admin-dong 신사동 \
+  --gu 강남구 \
+  --limit 100
+```
+
+`--filter`가 필요하거나 게시 계약을 점검해야 할 때는 `--fast`를 빼고 full-contract query를 사용한다. fast query가 `product_not_ready` 또는 계약 오류를 반환하면 fixture나 추정값으로 대체하지 말고 아래 진단 흐름을 수행한다.
+
+### Contract diagnostics (only when needed)
+
+1. 환경 설정만 확인한다. 이 명령은 네트워크를 호출하지 않는다.
 
 ```bash
 npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.py -- preflight
@@ -44,28 +71,7 @@ npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.p
 npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.py -- describe --product-id weather_place_risk_window
 ```
 
-4. 행정동 이름과 `1..500` 범위의 limit으로 data page를 조회한다.
-
-```bash
-npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.py -- query \
-  --product-id weather_place_risk_window \
-  --admin-dong 잠실본동 \
-  --from 2026-08-01 \
-  --to 2026-08-07 \
-  --limit 100
-```
-
-동명이명인 `신사동`은 자치구를 확인한 뒤 다음처럼 조회한다.
-
-```bash
-npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.py -- query \
-  --product-id weather_place_risk_window \
-  --admin-dong 신사동 \
-  --gu 강남구 \
-  --limit 100
-```
-
-응답의 `registration_ready`, `publication_id`, `blockers`를 먼저 확인한다. data 응답의 `next_cursor`는 같은 제품의 다음 page에만 그대로 재사용한다. publication이 바뀌면 cursor는 `409`로 만료된다.
+진단 응답의 `registration_ready`, `publication_id`, `blockers`를 확인한다. fast/full data 응답의 `next_cursor`는 같은 제품의 다음 page에만 그대로 재사용하며 publication이 바뀌면 cursor는 `409`로 만료된다.
 
 ## Boundaries
 

--- a/seoul-weather-risk/scripts/seoul_weather_risk.py
+++ b/seoul-weather-risk/scripts/seoul_weather_risk.py
@@ -371,6 +371,7 @@ def _parser() -> argparse.ArgumentParser:
     describe.add_argument("--product-id", required=True)
 
     query = commands.add_parser("query", help="제품 data page 조회")
+    query.add_argument("--fast", action="store_true", help="bundle/product metadata 확인을 생략하고 data만 조회")
     query.add_argument("--product-id", required=True)
     query.add_argument("--filter", action="append", default=[], metavar="COLUMN=VALUE")
     query.add_argument("--admin-dong", help="서울 행정동 이름")
@@ -401,8 +402,12 @@ def run(argv: list[str]) -> int:
         else:
             if not 1 <= args.limit <= 500:
                 raise SkillError("invalid_limit", "limit은 1부터 500 사이여야 합니다.")
-            _bundle(config)
-            detail = _detail(config, args.product_id)
+            if args.fast and args.filter:
+                raise SkillError("fast_query_filter_unsupported", "--fast에서는 --filter를 사용할 수 없습니다.")
+            detail: dict[str, Any] | None = None
+            if not args.fast:
+                _bundle(config)
+                detail = _detail(config, args.product_id)
             filters = _filters(args.filter)
             if args.gu is not None and args.admin_dong is None:
                 raise SkillError("invalid_location_input", "--gu는 --admin-dong과 함께 사용해야 합니다.")
@@ -418,10 +423,11 @@ def run(argv: list[str]) -> int:
                     )
                 resolved = _resolve_admin_dong(args.admin_dong, args.gu)
                 filters["place_id"] = resolved["place_id"]
-            allowed_columns = {column["name"] for column in detail["metadata"].get("columns", [])}
-            unknown = sorted(set(filters) - allowed_columns)
-            if unknown:
-                raise SkillError("unknown_filter", f"공개 projection에 없는 필터입니다: {', '.join(unknown)}")
+            if detail is not None:
+                allowed_columns = {column["name"] for column in detail["metadata"].get("columns", [])}
+                unknown = sorted(set(filters) - allowed_columns)
+                if unknown:
+                    raise SkillError("unknown_filter", f"공개 projection에 없는 필터입니다: {', '.join(unknown)}")
             request_query = {**filters, "limit": str(args.limit)}
             if args.from_value is not None:
                 request_query["from"] = _time_bound(args.from_value, "from")

--- a/seoul-weather-risk/scripts/seoul_weather_risk.py
+++ b/seoul-weather-risk/scripts/seoul_weather_risk.py
@@ -20,16 +20,7 @@ from urllib.request import HTTPRedirectHandler, Request, build_opener
 SKILL_BUNDLE_ID = "seoul-weather-risk"
 PROXY_BASE_URL_ENV = "KSKILL_PROXY_BASE_URL"
 DEFAULT_PROXY_BASE_URL = "https://k-skill-proxy.nomadamas.org"
-LOCAL_DIRECT_ENV = "KSKILL_LOCAL_DIRECT"
-SKILL_API_BASE_URL_ENV = "ASK_SEOUL_SKILL_API_BASE_URL"
-MARKETPLACE_API_KEY_ENV = "MARKETPLACE_API_KEY"
 PROXY_DISABLED_VALUES = frozenset({"off", "false", "0", "disable", "disabled", "none"})
-LOCAL_DIRECT_ENABLED_VALUES = frozenset({"1", "true", "on", "yes"})
-LOCAL_DIRECT_DOTENV_NAMES = frozenset({
-    LOCAL_DIRECT_ENV,
-    SKILL_API_BASE_URL_ENV,
-    MARKETPLACE_API_KEY_ENV,
-})
 PROXY_ROUTE_ROOT = "/v1/ask-seoul/weather-risk"
 LOCATION_MAPPING_PATH = pathlib.Path(__file__).resolve().parents[1] / "references" / "admin-dong-place-map.json"
 LOCATION_MAPPING_VERSION = "kma_admin_dong_grid_20260325"
@@ -65,54 +56,14 @@ class _NoRedirect(HTTPRedirectHandler):
 @dataclass(frozen=True)
 class ApiConfig:
     base_url: str
-    mode: str = "hosted_proxy"
-    bearer_token: str | None = None
 
 
 def _json(value: Any) -> str:
     return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
 
 
-def _local_direct_config(values: dict[str, str]) -> ApiConfig:
-    base_url = values.get(SKILL_API_BASE_URL_ENV, "").strip()
-    bearer_token = values.get(MARKETPLACE_API_KEY_ENV, "").strip()
-    if not base_url or base_url == "replace-me":
-        raise SkillError("local_direct_not_configured", "local direct API base URL이 필요합니다.")
-    if not bearer_token or bearer_token == "replace-me":
-        raise SkillError("local_direct_not_configured", "local direct Marketplace API key가 필요합니다.")
-
-    parsed = urlparse(base_url)
-    local_http = parsed.scheme == "http" and parsed.hostname in {"127.0.0.1", "localhost", "::1"}
-    if (parsed.scheme != "https" and not local_http) or not parsed.netloc or parsed.path not in {"", "/"} or parsed.query or parsed.fragment:
-        raise SkillError("invalid_local_direct_base_url", "local direct API base URL은 HTTPS origin이어야 합니다.")
-    if parsed.username or parsed.password:
-        raise SkillError("invalid_local_direct_base_url", "local direct API base URL에 사용자 정보는 포함할 수 없습니다.")
-    return ApiConfig(base_url=base_url.rstrip("/"), mode="local_direct", bearer_token=bearer_token)
-
-
-def _current_directory_dotenv() -> dict[str, str]:
-    path = pathlib.Path.cwd() / ".env"
-    try:
-        lines = path.read_text(encoding="utf-8").splitlines()
-    except OSError:
-        return {}
-
-    values: dict[str, str] = {}
-    for line in lines:
-        stripped = line.strip()
-        if not stripped or stripped.startswith("#") or "=" not in stripped:
-            continue
-        name, value = stripped.split("=", 1)
-        name = name.strip()
-        if name in LOCAL_DIRECT_DOTENV_NAMES:
-            values[name] = value.strip().strip('"').strip("'")
-    return values
-
-
 def _api_config(environ: dict[str, str] | None = None) -> ApiConfig:
-    values = ({**_current_directory_dotenv(), **os.environ} if environ is None else environ)
-    if values.get(LOCAL_DIRECT_ENV, "").strip().casefold() in LOCAL_DIRECT_ENABLED_VALUES:
-        return _local_direct_config(values)
+    values = os.environ if environ is None else environ
     configured = values.get(PROXY_BASE_URL_ENV, "").strip()
     if configured.casefold() in PROXY_DISABLED_VALUES:
         raise SkillError("proxy_disabled", f"{PROXY_BASE_URL_ENV}가 비활성화되어 있습니다.")
@@ -159,8 +110,6 @@ def _request_json(config: ApiConfig, path: str, query: dict[str, str] | None = N
         "Accept": "application/json",
         "User-Agent": "k-skill-seoul-weather-risk/1",
     }
-    if config.bearer_token:
-        headers["Authorization"] = f"Bearer {config.bearer_token}"
     request = Request(url, headers=headers)
     try:
         with build_opener(_NoRedirect).open(request, timeout=15) as response:
@@ -399,22 +348,16 @@ def _validate_product_id(product_id: str) -> None:
 
 
 def _bundle(config: ApiConfig) -> dict[str, Any]:
-    if config.mode == "local_direct":
-        return _validate_bundle(_request_json(config, f"/skill/v1/bundles/{SKILL_BUNDLE_ID}"))
     return _validate_bundle(_request_json(config, f"{PROXY_ROUTE_ROOT}/bundle"))
 
 
 def _detail(config: ApiConfig, product_id: str) -> dict[str, Any]:
     _validate_product_id(product_id)
-    if config.mode == "local_direct":
-        return _validate_product(_request_json(config, f"/skill/v1/products/{product_id}"), product_id)
     return _validate_product(_request_json(config, f"{PROXY_ROUTE_ROOT}/product"), product_id)
 
 
 def _data(config: ApiConfig, product_id: str, query: dict[str, str], limit: int) -> dict[str, Any]:
     _validate_product_id(product_id)
-    if config.mode == "local_direct":
-        return _validate_data(_request_json(config, f"/skill/v1/products/{product_id}/data", query), product_id, limit)
     return _validate_data(_request_json(config, f"{PROXY_ROUTE_ROOT}/data", query), product_id, limit)
 
 
@@ -446,11 +389,9 @@ def run(argv: list[str]) -> int:
         if args.command == "preflight":
             result = {
                 "status": "ok",
-                "mode": config.mode,
+                "mode": "hosted_proxy",
                 "live_network": False,
-                "user_api_key_required": config.mode == "local_direct",
-                "proxy_base_url_configured": config.mode == "hosted_proxy",
-                "local_direct_base_url_configured": config.mode == "local_direct",
+                "proxy_base_url_configured": True,
             }
         elif args.command == "catalog":
             result = _bundle(config)

--- a/seoul-weather-risk/skill.json
+++ b/seoul-weather-risk/skill.json
@@ -1,9 +1,9 @@
 {
   "name": "seoul-weather-risk",
-  "description": "서울 행정동 이름을 정식명 우선·허용된 결정적 표기 별칭만으로 정규 place_id로 해석해 ASK 서울의 장소별 기상 위험 예상 시간대(weather_place_risk_window) 단일 제품을 hosted k-skill proxy에서 읽기 전용 조회한다. 기본 경로에는 사용자 API Key와 place_id 입력이 필요 없으며, 등록 전에는 명시적으로 local-direct 검증을 할 수 있다.",
+  "description": "서울 행정동 이름을 정식명 우선·허용된 결정적 표기 별칭만으로 정규 place_id로 해석해 ASK 서울의 장소별 기상 위험 예상 시간대(weather_place_risk_window) 단일 제품을 hosted k-skill proxy에서 읽기 전용 조회한다. 사용자 API Key와 place_id 입력은 필요하지 않다.",
   "profiles": [
     "proxy",
     "lookup"
   ],
-  "frontmatter": "name: seoul-weather-risk\ndescription: 서울 행정동 이름을 정식명 우선·허용된 결정적 표기 별칭만으로 정규 place_id로 해석해 ASK 서울의 장소별 기상 위험 예상 시간대(weather_place_risk_window) 단일 제품을 hosted k-skill proxy에서 읽기 전용 조회한다. 기본 경로에는 사용자 API Key와 place_id 입력이 필요 없으며, 등록 전에는 명시적으로 local-direct 검증을 할 수 있다.\nlicense: MIT\nmetadata:\n  category: public-data\n  locale: ko-KR\n  phase: live-client"
+  "frontmatter": "name: seoul-weather-risk\ndescription: 서울 행정동 이름을 정식명 우선·허용된 결정적 표기 별칭만으로 정규 place_id로 해석해 ASK 서울의 장소별 기상 위험 예상 시간대(weather_place_risk_window) 단일 제품을 hosted k-skill proxy에서 읽기 전용 조회한다. 사용자 API Key와 place_id 입력은 필요하지 않다.\nlicense: MIT\nmetadata:\n  category: public-data\n  locale: ko-KR\n  phase: live-client"
 }

--- a/seoul-weather-risk/tests/test_seoul_weather_risk.py
+++ b/seoul-weather-risk/tests/test_seoul_weather_risk.py
@@ -156,6 +156,23 @@ class ApiClientTests(unittest.TestCase):
         })
         self.assertTrue(all(request["authorization"] is None for request in self.api.requests))
 
+    def test_local_direct_settings_are_ignored_and_hosted_proxy_remains_the_only_route(self):
+        with patch.dict(os.environ, {
+            "KSKILL_LOCAL_DIRECT": "1",
+            "ASK_SEOUL_SKILL_API_BASE_URL": self.api.base_url,
+            "MARKETPLACE_API_KEY": "legacy-marketplace-key-must-not-be-used",
+        }, clear=False):
+            stdout = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
+                code = seoul_weather_risk.run(["catalog"])
+
+        self.assertEqual(code, 0)
+        self.assertEqual([request["path"] for request in self.api.requests], [
+            "/v1/ask-seoul/weather-risk/bundle",
+        ])
+        self.assertIsNone(self.api.requests[0]["authorization"])
+        self.assertNotIn("legacy-marketplace-key-must-not-be-used", stdout.getvalue())
+
     def test_query_keeps_explicit_datetime_bounds_unchanged(self):
         stdout = io.StringIO()
         with contextlib.redirect_stdout(stdout):
@@ -172,77 +189,6 @@ class ApiClientTests(unittest.TestCase):
             "limit": ["100"],
         })
 
-    def test_local_direct_mode_uses_marketplace_bearer_and_skill_paths(self):
-        self.api.responses = {
-            "/skill/v1/bundles/seoul-weather-risk": (200, "application/json", bundle(), {}),
-            f"/skill/v1/products/{PRODUCT_ID}": (200, "application/json", detail(), {}),
-            f"/skill/v1/products/{PRODUCT_ID}/data": (200, "application/json", data(limit=1), {}),
-        }
-        names = ("KSKILL_LOCAL_DIRECT", "ASK_SEOUL_SKILL_API_BASE_URL", "MARKETPLACE_API_KEY")
-        previous = {name: os.environ.get(name) for name in names}
-        self.addCleanup(lambda: [os.environ.pop(name, None) if value is None else os.environ.__setitem__(name, value) for name, value in previous.items()])
-        os.environ["KSKILL_LOCAL_DIRECT"] = "1"
-        os.environ["ASK_SEOUL_SKILL_API_BASE_URL"] = self.api.base_url
-        os.environ["MARKETPLACE_API_KEY"] = "test-marketplace-key"
-
-        stdout = io.StringIO()
-        with contextlib.redirect_stdout(stdout):
-            code = seoul_weather_risk.run([
-                "query", "--product-id", PRODUCT_ID, "--admin-dong", "성수2가3동", "--limit", "1",
-            ])
-
-        self.assertEqual(code, 0)
-        self.assertEqual([request["path"] for request in self.api.requests], [
-            "/skill/v1/bundles/seoul-weather-risk",
-            f"/skill/v1/products/{PRODUCT_ID}",
-            f"/skill/v1/products/{PRODUCT_ID}/data",
-        ])
-        self.assertTrue(all(request["authorization"] == "Bearer test-marketplace-key" for request in self.api.requests))
-        self.assertEqual(self.api.requests[-1]["query"]["place_id"], ["seoul_admd_1120069000"])
-
-    def test_local_direct_mode_loads_current_directory_dotenv(self):
-        self.api.responses = {
-            "/skill/v1/bundles/seoul-weather-risk": (200, "application/json", bundle(), {}),
-        }
-        names = ("KSKILL_LOCAL_DIRECT", "ASK_SEOUL_SKILL_API_BASE_URL", "MARKETPLACE_API_KEY")
-        previous = {name: os.environ.get(name) for name in names}
-        self.addCleanup(lambda: [os.environ.pop(name, None) if value is None else os.environ.__setitem__(name, value) for name, value in previous.items()])
-        for name in names:
-            os.environ.pop(name, None)
-
-        with tempfile.TemporaryDirectory() as directory:
-            pathlib.Path(directory, ".env").write_text(
-                "KSKILL_LOCAL_DIRECT=1\n"
-                f"ASK_SEOUL_SKILL_API_BASE_URL={self.api.base_url}\n"
-                "MARKETPLACE_API_KEY=test-marketplace-key\n",
-                encoding="utf-8",
-            )
-            stdout = io.StringIO()
-            with patch.object(seoul_weather_risk.pathlib.Path, "cwd", return_value=pathlib.Path(directory)):
-                with contextlib.redirect_stdout(stdout):
-                    code = seoul_weather_risk.run(["catalog"])
-
-        self.assertEqual(code, 0)
-        self.assertEqual(json.loads(stdout.getvalue())["bundle_id"], "seoul-weather-risk")
-        self.assertEqual(self.api.requests[0]["path"], "/skill/v1/bundles/seoul-weather-risk")
-        self.assertEqual(self.api.requests[0]["authorization"], "Bearer test-marketplace-key")
-
-    def test_local_direct_preflight_reports_direct_not_proxy_configuration(self):
-        stdout = io.StringIO()
-        with patch.dict(os.environ, {
-            "KSKILL_LOCAL_DIRECT": "1",
-            "ASK_SEOUL_SKILL_API_BASE_URL": self.api.base_url,
-            "MARKETPLACE_API_KEY": "test-marketplace-key",
-        }, clear=False):
-            with contextlib.redirect_stdout(stdout):
-                code = seoul_weather_risk.run(["preflight"])
-
-        self.assertEqual(code, 0)
-        payload = json.loads(stdout.getvalue())
-        self.assertEqual(payload["mode"], "local_direct")
-        self.assertTrue(payload["user_api_key_required"])
-        self.assertFalse(payload["proxy_base_url_configured"])
-        self.assertTrue(payload["local_direct_base_url_configured"])
 
     def test_query_maps_admin_dong_to_place_id_before_proxy_request(self):
         self.api.responses["/v1/ask-seoul/weather-risk/data"] = (
@@ -561,7 +507,8 @@ class CliTests(unittest.TestCase):
         payload = json.loads(stdout.getvalue())
         self.assertEqual(payload["mode"], "hosted_proxy")
         self.assertFalse(payload["live_network"])
-        self.assertFalse(payload["user_api_key_required"])
+        self.assertTrue(payload["proxy_base_url_configured"])
+        self.assertEqual(set(payload), {"status", "mode", "live_network", "proxy_base_url_configured"})
         self.assertNotIn("legacy-user-key-must-not-be-used", stdout.getvalue())
 
     def test_parser_has_no_credential_or_base_url_option(self):

--- a/seoul-weather-risk/tests/test_seoul_weather_risk.py
+++ b/seoul-weather-risk/tests/test_seoul_weather_risk.py
@@ -156,6 +156,27 @@ class ApiClientTests(unittest.TestCase):
         })
         self.assertTrue(all(request["authorization"] is None for request in self.api.requests))
 
+    def test_fast_query_uses_only_data_route_without_metadata_round_trips(self):
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            code = seoul_weather_risk.run([
+                "query", "--fast", "--product-id", PRODUCT_ID,
+                "--admin-dong", "잠실본동", "--from", "2026-08-05", "--to", "2026-08-05", "--limit", "100",
+            ])
+
+        self.assertEqual(code, 0)
+        self.assertEqual(json.loads(stdout.getvalue())["row_count"], 1)
+        self.assertEqual([request["path"] for request in self.api.requests], [
+            "/v1/ask-seoul/weather-risk/data",
+        ])
+        self.assertEqual(self.api.requests[0]["query"], {
+            "place_id": ["seoul_admd_1171065000"],
+            "from": ["2026-08-05 00:00:00"],
+            "to": ["2026-08-05 23:59:59"],
+            "limit": ["100"],
+        })
+        self.assertIsNone(self.api.requests[0]["authorization"])
+
     def test_local_direct_settings_are_ignored_and_hosted_proxy_remains_the_only_route(self):
         with patch.dict(os.environ, {
             "KSKILL_LOCAL_DIRECT": "1",


### PR DESCRIPTION
## 한 줄 목적

등록 전 local-direct·Marketplace API key fallback을 제거하고, 일반 `seoul-weather-risk` 조회를 hosted data 요청 1회로 고정합니다.

## 문제와 증거

기존 helper는 `KSKILL_LOCAL_DIRECT=1`일 때 현재 작업 폴더 `.env`의 direct API URL과 Marketplace key를 읽어 `/skill/v1/...`에 Bearer 인증으로 요청했습니다. hosted 사용자 경로와 등록 전 우회 경로가 함께 존재했고, 일반 `query`도 bundle·product metadata·data를 순차 호출해 live GET 3회가 필요했습니다.

## 변경 사항

- API 설정에서 dotenv 읽기, local-direct 분기, Marketplace key/Bearer 헤더를 삭제했습니다.
- bundle·product·data 요청을 `/v1/ask-seoul/weather-risk/{bundle,product,data}` hosted proxy route로 단일화했습니다.
- `query --fast`를 추가해 행정동·날짜·limit·cursor 검증 후 data route만 1회 호출합니다.
- fast path에서는 임의 `--filter`를 거부하고, 기존 full-contract query와 `catalog/describe` 진단 경로는 보존했습니다.
- 일반 사용자 instruction·feature guide를 fast path 우선, 오류 시에만 계약 진단을 수행하도록 정리했습니다.
- CLI 번들·행정동 reference·generic/dolshoi 스냅샷과 회귀 테스트를 동기화했습니다.

## 개선 전 / 후

| 구분 | 변경 전 | 변경 후 |
| --- | --- | --- |
| 일반 query live GET | bundle + product + data = 3회 | data = 1회 |
| 요청 경로 | hosted proxy 또는 local-direct | hosted proxy만 사용 |
| 인증 | direct 경로에서 Marketplace Bearer 사용 가능 | 사용자 API key·Authorization 헤더 미사용 |
| 오류 진단 | 매번 metadata 왕복 | fast 실패·filter 필요 시에만 full contract |

## 검증 결과

- `python -m unittest seoul-weather-risk.tests.test_seoul_weather_risk` — 31개 통과
- `npm.cmd run sync:cli-skills -- --check` — 122 skills, 137 assets exact
- 서울 날씨 generic/dolshoi 스냅샷 직접 비교 — 일치
- `git diff --check` — 통과
- fork PR #6 (`ASAC-DE-bigkk/k-skill`)을 `dev`에 병합 — merge commit `be1a483089055987d6d331b2799552b112dc704c`
- `node --test packages/k-skill-cli/test/cli.test.js` — 기존 upstream 기준선의 CRLF·번들 drift로 4개 실패(assembly mode marker, directory asset, snapshot); fast path 관련 Python 테스트와 서울 날씨 스냅샷은 통과

## 영향 범위

- 변경 범위는 `seoul-weather-risk` helper·문서·CLI 생성 번들·reference·스냅샷입니다.
- ASK 서울 proxy 운영 환경의 서비스 키, 다른 스킬의 서버 설정, Serving artifact는 변경하지 않습니다.
- full-contract query와 hosted proxy route 계약은 유지합니다.

## 후속 작업

- hosted proxy 등록 및 readiness가 완료된 뒤 실제 잠실본동 fast/full 조회 smoke를 수행합니다.
- PR은 upstream `dev` 기준 draft 상태로 유지합니다.

Related to #552
