### PR TITLE
fix(korean-cinema-search): remap inverted Lotte seat labels

### DIFF
--- a/.changeset/lotte-seat-label-swap.md
+++ b/.changeset/lotte-seat-label-swap.md
@@ -1,0 +1,5 @@
+---
+"@nomadamas/k-skill": patch
+---
+
+Remap inverted Lotte Cinema daiso bookedSeats/remainingSeats labels so remaining seats are reported correctly.

--- a/docs/features/korean-cinema-search.md
+++ b/docs/features/korean-cinema-search.md
@@ -29,6 +29,13 @@ npx --yes daiso get /api/lottecinema/movies --keyword 월드타워 --playDate <Y
 npx --yes daiso get /api/lottecinema/seats --keyword 월드타워 --playDate <YYYYMMDD> --limit 10 --json
 ```
 
+롯데시네마 `daiso` 응답의 `bookedSeats`는 공식 `BookingSeatCount`(잔여/예매 가능 좌석)이고 `remainingSeats`는 그 반대값이다. 잔여석을 말할 때는 remap helper를 통과시킨다.
+
+```bash
+npx --yes daiso get /api/lottecinema/seats --keyword 월드타워 --playDate <YYYYMMDD> --limit 10 --json \
+  | npx -y @nomadamas/k-skill@0 exec korean-cinema-search scripts/remap_lotte_seats.js --
+```
+
 ## 원본 저장소 clone fallback
 
 ```bash
@@ -64,7 +71,8 @@ node dist/bin.js get /api/lottecinema/seats --keyword 월드타워 --playDate <Y
 4. `/api/cgv/movies`, `/api/megabox/movies`, `/api/lottecinema/movies` 로 상영작을 확인한다.
 5. CGV는 `/api/cgv/timetable` 로 시간표를 본다.
 6. 메가박스와 롯데시네마는 `/api/megabox/seats`, `/api/lottecinema/seats` 로 잔여석을 본다.
-7. 예매와 결제는 자동화하지 않는다.
+7. 롯데시네마 JSON만 `remap_lotte_seats.js`로 `bookedSeats`/`remainingSeats` 라벨을 교정한 뒤 잔여석을 말한다.
+8. 예매와 결제는 자동화하지 않는다.
 
 ## 응답 원칙
 

--- a/korean-cinema-search/instruction.md
+++ b/korean-cinema-search/instruction.md
@@ -52,6 +52,15 @@ npx --yes daiso get /api/lottecinema/movies --keyword 월드타워 --playDate <Y
 npx --yes daiso get /api/lottecinema/seats --keyword 월드타워 --playDate <YYYYMMDD> --limit 10 --json
 ```
 
+롯데시네마 `movies`/`seats` JSON은 조회 직후 반드시 remap 한다. `daiso@1.0.10`은 공식 `BookingSeatCount`(예매 가능 좌석)를 `bookedSeats`에 넣고 `remainingSeats`를 그 반대값으로 계산한다. 원라벨 그대로 보고하면 잔여/매진이 뒤집힌다.
+
+```bash
+npx --yes daiso get /api/lottecinema/seats --keyword 월드타워 --playDate <YYYYMMDD> --limit 10 --json \
+  | npx -y @nomadamas/k-skill@0 exec korean-cinema-search scripts/remap_lotte_seats.js --
+npx --yes daiso lottecinema-seats --playDate <YYYYMMDD> --theaterId 3032 --json \
+  | npx -y @nomadamas/k-skill@0 exec korean-cinema-search scripts/remap_lotte_seats.js --
+```
+
 반복 사용이면 전역 설치도 가능하다.
 
 ```bash
@@ -75,6 +84,8 @@ node dist/bin.js get /api/cgv/timetable --keyword 강남 --playDate <YYYYMMDD> -
 node dist/bin.js get /api/megabox/seats --keyword 코엑스 --playDate <YYYYMMDD> --limit 10 --json
 node dist/bin.js get /api/lottecinema/seats --keyword 월드타워 --playDate <YYYYMMDD> --limit 10 --json
 ```
+
+clone fallback로 롯데시네마 좌석을 조회해도 같은 remap helper를 통과시킨다.
 
 ## Required inputs
 
@@ -136,11 +147,12 @@ CGV는 시간표 중심으로 본다.
 npx --yes daiso get /api/cgv/timetable --keyword 강남 --playDate <YYYYMMDD> --json
 ```
 
-메가박스와 롯데시네마는 잔여석 endpoint를 사용할 수 있다.
+메가박스와 롯데시네마는 잔여석 endpoint를 사용할 수 있다. 롯데시네마만은 원라벨 JSON을 그대로 읽지 말고 remap helper를 통과시킨다.
 
 ```bash
 npx --yes daiso get /api/megabox/seats --keyword 코엑스 --playDate <YYYYMMDD> --limit 10 --json
-npx --yes daiso get /api/lottecinema/seats --keyword 월드타워 --playDate <YYYYMMDD> --limit 10 --json
+npx --yes daiso get /api/lottecinema/seats --keyword 월드타워 --playDate <YYYYMMDD> --limit 10 --json \
+  | npx -y @nomadamas/k-skill@0 exec korean-cinema-search scripts/remap_lotte_seats.js --
 ```
 
 ### 5. Respond conservatively
@@ -150,7 +162,7 @@ npx --yes daiso get /api/lottecinema/seats --keyword 월드타워 --playDate <YY
 - 영화관 체인
 - 기준 지역이나 지점
 - 상영작 또는 선택 영화
-- 시간표와 잔여석
+- 시간표와 잔여석 (롯데시네마는 remap 이후 `remainingSeats`만 잔여석으로 말한다)
 - 조회 시각과 공개 endpoint 특성상 변동 가능하다는 점
 
 예매와 결제는 자동화하지 않는다.
@@ -168,6 +180,7 @@ npx --yes daiso get /api/lottecinema/seats --keyword 월드타워 --playDate <YY
 - public endpoint는 upstream 상태에 따라 간헐적인 5xx를 줄 수 있다.
 - 지역 키워드가 넓으면 다른 지점이 섞일 수 있다.
 - 시간표와 잔여석은 시점에 따라 달라진다.
+- 롯데시네마 `daiso` 원라벨 `bookedSeats`/`remainingSeats`는 반대이다. remap 없이 보고하면 잔여 0석을 매진으로 읽는다.
 - 일부 체인은 상영작, 시간표, 잔여석 endpoint의 입력값이 다르므로 theaterId, movieId가 있으면 그 값을 우선 사용한다.
 
 ## Notes

--- a/korean-cinema-search/scripts/remap_lotte_seats.js
+++ b/korean-cinema-search/scripts/remap_lotte_seats.js
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+
+function isFiniteNumber(value) {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function isLotteSeatRecord(value) {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    isFiniteNumber(value.totalSeats) &&
+    isFiniteNumber(value.bookedSeats) &&
+    isFiniteNumber(value.remainingSeats)
+  );
+}
+
+function remapLotteSeatRecord(record) {
+  if (!isLotteSeatRecord(record)) {
+    return record;
+  }
+
+  return {
+    ...record,
+    bookedSeats: record.remainingSeats,
+    remainingSeats: record.bookedSeats,
+    seatFieldsRemapped: true,
+  };
+}
+
+function remapLotteSeatsPayload(value, seen = new WeakSet()) {
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+  if (seen.has(value)) {
+    return value;
+  }
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.map((item) => remapLotteSeatsPayload(item, seen));
+  }
+
+  if (isLotteSeatRecord(value)) {
+    const remapped = remapLotteSeatRecord(value);
+    const nested = {};
+    for (const [key, child] of Object.entries(remapped)) {
+      if (key === "bookedSeats" || key === "remainingSeats" || key === "seatFieldsRemapped") {
+        nested[key] = child;
+        continue;
+      }
+      nested[key] = remapLotteSeatsPayload(child, seen);
+    }
+    return nested;
+  }
+
+  const out = {};
+  for (const [key, child] of Object.entries(value)) {
+    out[key] = remapLotteSeatsPayload(child, seen);
+  }
+  return out;
+}
+
+function readInput(argv) {
+  const fileFlag = argv.indexOf("--file");
+  if (fileFlag !== -1) {
+    const filePath = argv[fileFlag + 1];
+    if (!filePath) {
+      throw new Error("Missing value after --file");
+    }
+    return fs.readFileSync(filePath, "utf8");
+  }
+
+  return fs.readFileSync(0, "utf8");
+}
+
+function main(argv = process.argv.slice(2)) {
+  const raw = readInput(argv).trim();
+  if (!raw) {
+    throw new Error("Provide daiso lottecinema JSON on stdin or with --file <path>.");
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(raw);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid JSON: ${message}`);
+  }
+
+  process.stdout.write(`${JSON.stringify(remapLotteSeatsPayload(payload), null, 2)}\n`);
+}
+
+module.exports = {
+  isLotteSeatRecord,
+  remapLotteSeatRecord,
+  remapLotteSeatsPayload,
+};
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/packages/k-skill-cli/skills/korean-cinema-search/instruction.md
+++ b/packages/k-skill-cli/skills/korean-cinema-search/instruction.md
@@ -52,6 +52,15 @@ npx --yes daiso get /api/lottecinema/movies --keyword 월드타워 --playDate <Y
 npx --yes daiso get /api/lottecinema/seats --keyword 월드타워 --playDate <YYYYMMDD> --limit 10 --json
 ```
 
+롯데시네마 `movies`/`seats` JSON은 조회 직후 반드시 remap 한다. `daiso@1.0.10`은 공식 `BookingSeatCount`(예매 가능 좌석)를 `bookedSeats`에 넣고 `remainingSeats`를 그 반대값으로 계산한다. 원라벨 그대로 보고하면 잔여/매진이 뒤집힌다.
+
+```bash
+npx --yes daiso get /api/lottecinema/seats --keyword 월드타워 --playDate <YYYYMMDD> --limit 10 --json \
+  | npx -y @nomadamas/k-skill@0 exec korean-cinema-search scripts/remap_lotte_seats.js --
+npx --yes daiso lottecinema-seats --playDate <YYYYMMDD> --theaterId 3032 --json \
+  | npx -y @nomadamas/k-skill@0 exec korean-cinema-search scripts/remap_lotte_seats.js --
+```
+
 반복 사용이면 전역 설치도 가능하다.
 
 ```bash
@@ -75,6 +84,8 @@ node dist/bin.js get /api/cgv/timetable --keyword 강남 --playDate <YYYYMMDD> -
 node dist/bin.js get /api/megabox/seats --keyword 코엑스 --playDate <YYYYMMDD> --limit 10 --json
 node dist/bin.js get /api/lottecinema/seats --keyword 월드타워 --playDate <YYYYMMDD> --limit 10 --json
 ```
+
+clone fallback로 롯데시네마 좌석을 조회해도 같은 remap helper를 통과시킨다.
 
 ## Required inputs
 
@@ -136,11 +147,12 @@ CGV는 시간표 중심으로 본다.
 npx --yes daiso get /api/cgv/timetable --keyword 강남 --playDate <YYYYMMDD> --json
 ```
 
-메가박스와 롯데시네마는 잔여석 endpoint를 사용할 수 있다.
+메가박스와 롯데시네마는 잔여석 endpoint를 사용할 수 있다. 롯데시네마만은 원라벨 JSON을 그대로 읽지 말고 remap helper를 통과시킨다.
 
 ```bash
 npx --yes daiso get /api/megabox/seats --keyword 코엑스 --playDate <YYYYMMDD> --limit 10 --json
-npx --yes daiso get /api/lottecinema/seats --keyword 월드타워 --playDate <YYYYMMDD> --limit 10 --json
+npx --yes daiso get /api/lottecinema/seats --keyword 월드타워 --playDate <YYYYMMDD> --limit 10 --json \
+  | npx -y @nomadamas/k-skill@0 exec korean-cinema-search scripts/remap_lotte_seats.js --
 ```
 
 ### 5. Respond conservatively
@@ -150,7 +162,7 @@ npx --yes daiso get /api/lottecinema/seats --keyword 월드타워 --playDate <YY
 - 영화관 체인
 - 기준 지역이나 지점
 - 상영작 또는 선택 영화
-- 시간표와 잔여석
+- 시간표와 잔여석 (롯데시네마는 remap 이후 `remainingSeats`만 잔여석으로 말한다)
 - 조회 시각과 공개 endpoint 특성상 변동 가능하다는 점
 
 예매와 결제는 자동화하지 않는다.
@@ -168,6 +180,7 @@ npx --yes daiso get /api/lottecinema/seats --keyword 월드타워 --playDate <YY
 - public endpoint는 upstream 상태에 따라 간헐적인 5xx를 줄 수 있다.
 - 지역 키워드가 넓으면 다른 지점이 섞일 수 있다.
 - 시간표와 잔여석은 시점에 따라 달라진다.
+- 롯데시네마 `daiso` 원라벨 `bookedSeats`/`remainingSeats`는 반대이다. remap 없이 보고하면 잔여 0석을 매진으로 읽는다.
 - 일부 체인은 상영작, 시간표, 잔여석 endpoint의 입력값이 다르므로 theaterId, movieId가 있으면 그 값을 우선 사용한다.
 
 ## Notes

--- a/packages/k-skill-cli/skills/korean-cinema-search/scripts/remap_lotte_seats.js
+++ b/packages/k-skill-cli/skills/korean-cinema-search/scripts/remap_lotte_seats.js
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+
+function isFiniteNumber(value) {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function isLotteSeatRecord(value) {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    isFiniteNumber(value.totalSeats) &&
+    isFiniteNumber(value.bookedSeats) &&
+    isFiniteNumber(value.remainingSeats)
+  );
+}
+
+function remapLotteSeatRecord(record) {
+  if (!isLotteSeatRecord(record)) {
+    return record;
+  }
+
+  return {
+    ...record,
+    bookedSeats: record.remainingSeats,
+    remainingSeats: record.bookedSeats,
+    seatFieldsRemapped: true,
+  };
+}
+
+function remapLotteSeatsPayload(value, seen = new WeakSet()) {
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+  if (seen.has(value)) {
+    return value;
+  }
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.map((item) => remapLotteSeatsPayload(item, seen));
+  }
+
+  if (isLotteSeatRecord(value)) {
+    const remapped = remapLotteSeatRecord(value);
+    const nested = {};
+    for (const [key, child] of Object.entries(remapped)) {
+      if (key === "bookedSeats" || key === "remainingSeats" || key === "seatFieldsRemapped") {
+        nested[key] = child;
+        continue;
+      }
+      nested[key] = remapLotteSeatsPayload(child, seen);
+    }
+    return nested;
+  }
+
+  const out = {};
+  for (const [key, child] of Object.entries(value)) {
+    out[key] = remapLotteSeatsPayload(child, seen);
+  }
+  return out;
+}
+
+function readInput(argv) {
+  const fileFlag = argv.indexOf("--file");
+  if (fileFlag !== -1) {
+    const filePath = argv[fileFlag + 1];
+    if (!filePath) {
+      throw new Error("Missing value after --file");
+    }
+    return fs.readFileSync(filePath, "utf8");
+  }
+
+  return fs.readFileSync(0, "utf8");
+}
+
+function main(argv = process.argv.slice(2)) {
+  const raw = readInput(argv).trim();
+  if (!raw) {
+    throw new Error("Provide daiso lottecinema JSON on stdin or with --file <path>.");
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(raw);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid JSON: ${message}`);
+  }
+
+  process.stdout.write(`${JSON.stringify(remapLotteSeatsPayload(payload), null, 2)}\n`);
+}
+
+module.exports = {
+  isLotteSeatRecord,
+  remapLotteSeatRecord,
+  remapLotteSeatsPayload,
+};
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/packages/k-skill-cli/test/snapshots/korean-cinema-search.dolshoi.md
+++ b/packages/k-skill-cli/test/snapshots/korean-cinema-search.dolshoi.md
@@ -71,6 +71,15 @@ npx --yes daiso get /api/lottecinema/movies --keyword 월드타워 --playDate <Y
 npx --yes daiso get /api/lottecinema/seats --keyword 월드타워 --playDate <YYYYMMDD> --limit 10 --json
 ```
 
+롯데시네마 `movies`/`seats` JSON은 조회 직후 반드시 remap 한다. `daiso@1.0.10`은 공식 `BookingSeatCount`(예매 가능 좌석)를 `bookedSeats`에 넣고 `remainingSeats`를 그 반대값으로 계산한다. 원라벨 그대로 보고하면 잔여/매진이 뒤집힌다.
+
+```bash
+npx --yes daiso get /api/lottecinema/seats --keyword 월드타워 --playDate <YYYYMMDD> --limit 10 --json \
+  | npx -y @nomadamas/k-skill@0 exec korean-cinema-search scripts/remap_lotte_seats.js --
+npx --yes daiso lottecinema-seats --playDate <YYYYMMDD> --theaterId 3032 --json \
+  | npx -y @nomadamas/k-skill@0 exec korean-cinema-search scripts/remap_lotte_seats.js --
+```
+
 반복 사용이면 전역 설치도 가능하다.
 
 ```bash
@@ -94,6 +103,8 @@ node dist/bin.js get /api/cgv/timetable --keyword 강남 --playDate <YYYYMMDD> -
 node dist/bin.js get /api/megabox/seats --keyword 코엑스 --playDate <YYYYMMDD> --limit 10 --json
 node dist/bin.js get /api/lottecinema/seats --keyword 월드타워 --playDate <YYYYMMDD> --limit 10 --json
 ```
+
+clone fallback로 롯데시네마 좌석을 조회해도 같은 remap helper를 통과시킨다.
 
 ## Required inputs
 
@@ -155,11 +166,12 @@ CGV는 시간표 중심으로 본다.
 npx --yes daiso get /api/cgv/timetable --keyword 강남 --playDate <YYYYMMDD> --json
 ```
 
-메가박스와 롯데시네마는 잔여석 endpoint를 사용할 수 있다.
+메가박스와 롯데시네마는 잔여석 endpoint를 사용할 수 있다. 롯데시네마만은 원라벨 JSON을 그대로 읽지 말고 remap helper를 통과시킨다.
 
 ```bash
 npx --yes daiso get /api/megabox/seats --keyword 코엑스 --playDate <YYYYMMDD> --limit 10 --json
-npx --yes daiso get /api/lottecinema/seats --keyword 월드타워 --playDate <YYYYMMDD> --limit 10 --json
+npx --yes daiso get /api/lottecinema/seats --keyword 월드타워 --playDate <YYYYMMDD> --limit 10 --json \
+  | npx -y @nomadamas/k-skill@0 exec korean-cinema-search scripts/remap_lotte_seats.js --
 ```
 
 ### 5. Respond conservatively
@@ -169,7 +181,7 @@ npx --yes daiso get /api/lottecinema/seats --keyword 월드타워 --playDate <YY
 - 영화관 체인
 - 기준 지역이나 지점
 - 상영작 또는 선택 영화
-- 시간표와 잔여석
+- 시간표와 잔여석 (롯데시네마는 remap 이후 `remainingSeats`만 잔여석으로 말한다)
 - 조회 시각과 공개 endpoint 특성상 변동 가능하다는 점
 
 예매와 결제는 자동화하지 않는다.
@@ -187,6 +199,7 @@ npx --yes daiso get /api/lottecinema/seats --keyword 월드타워 --playDate <YY
 - public endpoint는 upstream 상태에 따라 간헐적인 5xx를 줄 수 있다.
 - 지역 키워드가 넓으면 다른 지점이 섞일 수 있다.
 - 시간표와 잔여석은 시점에 따라 달라진다.
+- 롯데시네마 `daiso` 원라벨 `bookedSeats`/`remainingSeats`는 반대이다. remap 없이 보고하면 잔여 0석을 매진으로 읽는다.
 - 일부 체인은 상영작, 시간표, 잔여석 endpoint의 입력값이 다르므로 theaterId, movieId가 있으면 그 값을 우선 사용한다.
 
 ## Notes

--- a/packages/k-skill-cli/test/snapshots/korean-cinema-search.generic.md
+++ b/packages/k-skill-cli/test/snapshots/korean-cinema-search.generic.md
@@ -70,6 +70,15 @@ npx --yes daiso get /api/lottecinema/movies --keyword 월드타워 --playDate <Y
 npx --yes daiso get /api/lottecinema/seats --keyword 월드타워 --playDate <YYYYMMDD> --limit 10 --json
 ```
 
+롯데시네마 `movies`/`seats` JSON은 조회 직후 반드시 remap 한다. `daiso@1.0.10`은 공식 `BookingSeatCount`(예매 가능 좌석)를 `bookedSeats`에 넣고 `remainingSeats`를 그 반대값으로 계산한다. 원라벨 그대로 보고하면 잔여/매진이 뒤집힌다.
+
+```bash
+npx --yes daiso get /api/lottecinema/seats --keyword 월드타워 --playDate <YYYYMMDD> --limit 10 --json \
+  | npx -y @nomadamas/k-skill@0 exec korean-cinema-search scripts/remap_lotte_seats.js --
+npx --yes daiso lottecinema-seats --playDate <YYYYMMDD> --theaterId 3032 --json \
+  | npx -y @nomadamas/k-skill@0 exec korean-cinema-search scripts/remap_lotte_seats.js --
+```
+
 반복 사용이면 전역 설치도 가능하다.
 
 ```bash
@@ -93,6 +102,8 @@ node dist/bin.js get /api/cgv/timetable --keyword 강남 --playDate <YYYYMMDD> -
 node dist/bin.js get /api/megabox/seats --keyword 코엑스 --playDate <YYYYMMDD> --limit 10 --json
 node dist/bin.js get /api/lottecinema/seats --keyword 월드타워 --playDate <YYYYMMDD> --limit 10 --json
 ```
+
+clone fallback로 롯데시네마 좌석을 조회해도 같은 remap helper를 통과시킨다.
 
 ## Required inputs
 
@@ -154,11 +165,12 @@ CGV는 시간표 중심으로 본다.
 npx --yes daiso get /api/cgv/timetable --keyword 강남 --playDate <YYYYMMDD> --json
 ```
 
-메가박스와 롯데시네마는 잔여석 endpoint를 사용할 수 있다.
+메가박스와 롯데시네마는 잔여석 endpoint를 사용할 수 있다. 롯데시네마만은 원라벨 JSON을 그대로 읽지 말고 remap helper를 통과시킨다.
 
 ```bash
 npx --yes daiso get /api/megabox/seats --keyword 코엑스 --playDate <YYYYMMDD> --limit 10 --json
-npx --yes daiso get /api/lottecinema/seats --keyword 월드타워 --playDate <YYYYMMDD> --limit 10 --json
+npx --yes daiso get /api/lottecinema/seats --keyword 월드타워 --playDate <YYYYMMDD> --limit 10 --json \
+  | npx -y @nomadamas/k-skill@0 exec korean-cinema-search scripts/remap_lotte_seats.js --
 ```
 
 ### 5. Respond conservatively
@@ -168,7 +180,7 @@ npx --yes daiso get /api/lottecinema/seats --keyword 월드타워 --playDate <YY
 - 영화관 체인
 - 기준 지역이나 지점
 - 상영작 또는 선택 영화
-- 시간표와 잔여석
+- 시간표와 잔여석 (롯데시네마는 remap 이후 `remainingSeats`만 잔여석으로 말한다)
 - 조회 시각과 공개 endpoint 특성상 변동 가능하다는 점
 
 예매와 결제는 자동화하지 않는다.
@@ -186,6 +198,7 @@ npx --yes daiso get /api/lottecinema/seats --keyword 월드타워 --playDate <YY
 - public endpoint는 upstream 상태에 따라 간헐적인 5xx를 줄 수 있다.
 - 지역 키워드가 넓으면 다른 지점이 섞일 수 있다.
 - 시간표와 잔여석은 시점에 따라 달라진다.
+- 롯데시네마 `daiso` 원라벨 `bookedSeats`/`remainingSeats`는 반대이다. remap 없이 보고하면 잔여 0석을 매진으로 읽는다.
 - 일부 체인은 상영작, 시간표, 잔여석 endpoint의 입력값이 다르므로 theaterId, movieId가 있으면 그 값을 우선 사용한다.
 
 ## Notes

--- a/scripts/test_remap_lotte_seats.js
+++ b/scripts/test_remap_lotte_seats.js
@@ -1,0 +1,88 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const childProcess = require("node:child_process");
+const path = require("node:path");
+
+const {
+  remapLotteSeatRecord,
+  remapLotteSeatsPayload,
+} = require("../korean-cinema-search/scripts/remap_lotte_seats.js");
+
+const REPO_ROOT = path.join(__dirname, "..");
+const HELPER = path.join(REPO_ROOT, "korean-cinema-search", "scripts", "remap_lotte_seats.js");
+
+function daisoSeat({ bookedSeats, remainingSeats, totalSeats = 79, extra = {} }) {
+  return {
+    startTime: "19:10",
+    movieName: "오디세이",
+    screenName: "3관",
+    theaterName: "안양일번가",
+    totalSeats,
+    bookedSeats,
+    remainingSeats,
+    ...extra,
+  };
+}
+
+test("remapLotteSeatRecord treats daiso bookedSeats as remaining seats", () => {
+  const remapped = remapLotteSeatRecord(daisoSeat({ bookedSeats: 56, remainingSeats: 23 }));
+
+  assert.equal(remapped.totalSeats, 79);
+  assert.equal(remapped.bookedSeats, 23);
+  assert.equal(remapped.remainingSeats, 56);
+  assert.equal(remapped.seatFieldsRemapped, true);
+});
+
+test("remapLotteSeatRecord turns a daiso all-available mislabel into remaining=total", () => {
+  const remapped = remapLotteSeatRecord(daisoSeat({ bookedSeats: 79, remainingSeats: 0, totalSeats: 79 }));
+
+  assert.equal(remapped.bookedSeats, 0);
+  assert.equal(remapped.remainingSeats, 79);
+});
+
+test("remapLotteSeatsPayload remaps nested daiso lottecinema-seats JSON", () => {
+  const payload = {
+    success: true,
+    data: {
+      playDate: "20260817",
+      seats: [
+        daisoSeat({ bookedSeats: 56, remainingSeats: 23 }),
+        daisoSeat({ bookedSeats: 78, remainingSeats: 0, totalSeats: 78, extra: { startTime: "21:20" } }),
+      ],
+    },
+  };
+
+  const remapped = remapLotteSeatsPayload(payload);
+  assert.equal(remapped.data.seats[0].bookedSeats, 23);
+  assert.equal(remapped.data.seats[0].remainingSeats, 56);
+  assert.equal(remapped.data.seats[1].bookedSeats, 0);
+  assert.equal(remapped.data.seats[1].remainingSeats, 78);
+});
+
+test("remapLotteSeatsPayload leaves megabox-style remaining-only records unchanged", () => {
+  const megabox = { movieName: "오디세이", remainingSeats: 40, totalSeats: 120 };
+  assert.deepEqual(remapLotteSeatsPayload(megabox), megabox);
+});
+
+test("remapLotteSeatsPayload leaves non-numeric seat fields unchanged", () => {
+  const broken = { totalSeats: 79, bookedSeats: "many", remainingSeats: 1 };
+  assert.deepEqual(remapLotteSeatsPayload(broken), broken);
+});
+
+test("CLI remaps stdin JSON and keeps wrapper metadata", () => {
+  const input = JSON.stringify({
+    success: true,
+    meta: { source: "daiso" },
+    data: { seats: [daisoSeat({ bookedSeats: 56, remainingSeats: 23 })] },
+  });
+  const stdout = childProcess.execFileSync(process.execPath, [HELPER], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    input,
+  });
+  const parsed = JSON.parse(stdout);
+  assert.equal(parsed.success, true);
+  assert.equal(parsed.meta.source, "daiso");
+  assert.equal(parsed.data.seats[0].bookedSeats, 23);
+  assert.equal(parsed.data.seats[0].remainingSeats, 56);
+});


### PR DESCRIPTION
## Upstream resolution (2026-08-19)

롯데시네마 `BookingSeatCount` 라벨 반전은 **upstream `hmmhmmhm/daiso-mcp`에서 해결됨**.

- 수정 PR: https://github.com/hmmhmmhm/daiso-mcp/pull/176 — **MERGED** 2026-08-18T01:32:02Z (`a92595e8`)
- Cloudflare Worker 배포: [Deploy to Cloudflare Workers #32088562457](https://github.com/hmmhmmhm/daiso-mcp/actions/runs/32088562457) — **success** (같은 커밋)
- 라이브 워커 `https://mcp.aka.page` 매핑: `remainingSeats = BookingSeatCount`, `bookedSeats = TotalSeatCount - BookingSeatCount`
- 2026-08-19 롯데시네마 안양일번가(`theaterId` 3032) 워커 응답 예: 오디세이 5관 16:20 `total=193 booked=15 remaining=178` (구 매핑이면 booked/remaining이 반대였음)
- npm `daiso@1.0.10` 로컬 번들은 아직 구 매핑. 다만 k-skill `korean-cinema-search`의 `npx daiso get`은 로컬 매핑이 아니라 **upstream Cloudflare Worker (`https://mcp.aka.page`)를 호출**한다. `k-skill-proxy` 경유 아님.
- 따라서 이 PR의 remapper를 워커 응답에 적용하면 **다시 뒤집혀서 틀어진다.** remapper는 머지하지 말고, 스킬은 워커 필드를 그대로 쓰면 된다.

원 이슈: #598

---

## Summary
Issue #598 is real. `daiso@1.0.10` maps Lotte official `BookingSeatCount` (available/remaining seats) onto `bookedSeats` and computes `remainingSeats = total - BookingSeatCount` (actual booked). This repo does not vendor daiso, so the skill now remaps those labels before agents report remaining seats.

## Evidence
Live 2026-08-17 롯데시네마 안양일번가 (`theaterId` 3032), 19:50 오디세이 5관:

| source | booked | remaining / available |
| --- | ---: | ---: |
| daiso `bookedSeats` / `remainingSeats` | 159 | 34 |
| remapper output | 34 | 159 |
| official `GetSeats` `BookingSeats` / `SeatStatusCode=0` | 34 | 159 |

Official `GetPlaySequence.BookingSeatCount` matched daiso `bookedSeats` (159), which is the available count.

## Change
- `korean-cinema-search/scripts/remap_lotte_seats.js` swaps numeric `bookedSeats`/`remainingSeats` on Lotte records
- instruction + feature doc require piping Lotte movies/seats JSON through `k-skill exec ... remap_lotte_seats.js`
- unit + CLI stdin tests; megabox remaining-only records stay unchanged

## Test plan
- [x] `node --test scripts/test_remap_lotte_seats.js` (RED then GREEN)
- [x] `node --test packages/k-skill-cli/test/cli.test.js`
- [x] live daiso 1.0.10 pipe vs official GetSeats
- [ ] CI on this PR

Closes #598

Plan: .omo/plans/fix-598-lotte-seat-swap.md