### PR TITLE
fix(skills): daiso-product-search·market-kurly-search Prerequisites에 npm 패키지 설치법 명시

### DIFF
--- a/.changeset/fix-skill-package-prerequisites.md
+++ b/.changeset/fix-skill-package-prerequisites.md
@@ -1,0 +1,5 @@
+---
+"@nomadamas/k-skill": patch
+---
+
+daiso-product-search와 market-kurly-search의 Prerequisites에 npm 패키지 설치법을 명시하고, daiso의 표면 직접 호출이 조용히 실패하는 조건을 Failure modes에 추가한다.

--- a/daiso-product-search/instruction.md
+++ b/daiso-product-search/instruction.md
@@ -26,7 +26,16 @@
 
 - 인터넷 연결
 - `node` 18+
-- 이 저장소의 `daiso-product-search` package 또는 동일 로직
+- `daiso-product-search` npm package
+
+설치:
+
+```bash
+npm install daiso-product-search
+```
+
+이 저장소에서 개발할 때는 루트에서 `npm install` 후 `packages/daiso-product-search`를 쓴다.
+package 설치가 막히면 표면을 직접 호출해 우회하지 말고 설치를 먼저 해결한다. 직접 호출은 실패가 성공처럼 보이는 응답을 준다(Failure modes 참고).
 
 ## Required inputs
 
@@ -161,6 +170,7 @@ console.log(result.pickupStock)
 - 현재 확인된 공식 표면은 **매장 내 aisle/진열 위치**를 직접 주지 않을 수 있다.
 - `selStrPkupStck` 403 → `/api/auth/request` 재호출 후 Bearer를 새로 빌드해 재시도한다.
 - Bearer 재시도 후에도 401/403이면 재고 수량은 `retrievalStatus: "blocked"` 로 표시하고, `selPkupStr` 기반 `pickupEligibility`(픽업 가능 여부)만 보조 정보로 제공한다.
+- **package 없이 표면을 직접 호출하면 조용히 틀린다.** `SearchGoods`는 검색어 파라미터명이 틀려도 400이 아니라 200에 전체 카탈로그를 돌려준다. 검색어는 JSON 바디가 아니라 쿼리스트링 `searchTerm`으로 보내야 하고, `selStr`도 바디 키가 틀리면 무관한 매장 1건만 준다. 둘 다 실패가 성공처럼 보이므로 반드시 package를 경유한다.
 
 ## Notes
 

--- a/market-kurly-search/instruction.md
+++ b/market-kurly-search/instruction.md
@@ -27,7 +27,15 @@
 
 - 인터넷 연결
 - `node` 18+
-- 이 저장소의 `market-kurly-search` package 또는 동일 로직
+- `market-kurly-search` npm package
+
+설치:
+
+```bash
+npm install market-kurly-search
+```
+
+이 저장소에서 개발할 때는 루트에서 `npm install` 후 `packages/market-kurly-search`를 쓴다.
 
 ## Required inputs
 

--- a/packages/k-skill-cli/skills/daiso-product-search/instruction.md
+++ b/packages/k-skill-cli/skills/daiso-product-search/instruction.md
@@ -26,7 +26,16 @@
 
 - 인터넷 연결
 - `node` 18+
-- 이 저장소의 `daiso-product-search` package 또는 동일 로직
+- `daiso-product-search` npm package
+
+설치:
+
+```bash
+npm install daiso-product-search
+```
+
+이 저장소에서 개발할 때는 루트에서 `npm install` 후 `packages/daiso-product-search`를 쓴다.
+package 설치가 막히면 표면을 직접 호출해 우회하지 말고 설치를 먼저 해결한다. 직접 호출은 실패가 성공처럼 보이는 응답을 준다(Failure modes 참고).
 
 ## Required inputs
 
@@ -161,6 +170,7 @@ console.log(result.pickupStock)
 - 현재 확인된 공식 표면은 **매장 내 aisle/진열 위치**를 직접 주지 않을 수 있다.
 - `selStrPkupStck` 403 → `/api/auth/request` 재호출 후 Bearer를 새로 빌드해 재시도한다.
 - Bearer 재시도 후에도 401/403이면 재고 수량은 `retrievalStatus: "blocked"` 로 표시하고, `selPkupStr` 기반 `pickupEligibility`(픽업 가능 여부)만 보조 정보로 제공한다.
+- **package 없이 표면을 직접 호출하면 조용히 틀린다.** `SearchGoods`는 검색어 파라미터명이 틀려도 400이 아니라 200에 전체 카탈로그를 돌려준다. 검색어는 JSON 바디가 아니라 쿼리스트링 `searchTerm`으로 보내야 하고, `selStr`도 바디 키가 틀리면 무관한 매장 1건만 준다. 둘 다 실패가 성공처럼 보이므로 반드시 package를 경유한다.
 
 ## Notes
 

--- a/packages/k-skill-cli/skills/market-kurly-search/instruction.md
+++ b/packages/k-skill-cli/skills/market-kurly-search/instruction.md
@@ -27,7 +27,15 @@
 
 - 인터넷 연결
 - `node` 18+
-- 이 저장소의 `market-kurly-search` package 또는 동일 로직
+- `market-kurly-search` npm package
+
+설치:
+
+```bash
+npm install market-kurly-search
+```
+
+이 저장소에서 개발할 때는 루트에서 `npm install` 후 `packages/market-kurly-search`를 쓴다.
 
 ## Required inputs
 

--- a/packages/k-skill-cli/test/snapshots/daiso-product-search.dolshoi.md
+++ b/packages/k-skill-cli/test/snapshots/daiso-product-search.dolshoi.md
@@ -45,7 +45,16 @@ Runtime mode: dolshoi (CloakBrowser available)
 
 - 인터넷 연결
 - `node` 18+
-- 이 저장소의 `daiso-product-search` package 또는 동일 로직
+- `daiso-product-search` npm package
+
+설치:
+
+```bash
+npm install daiso-product-search
+```
+
+이 저장소에서 개발할 때는 루트에서 `npm install` 후 `packages/daiso-product-search`를 쓴다.
+package 설치가 막히면 표면을 직접 호출해 우회하지 말고 설치를 먼저 해결한다. 직접 호출은 실패가 성공처럼 보이는 응답을 준다(Failure modes 참고).
 
 ## Required inputs
 
@@ -180,6 +189,7 @@ console.log(result.pickupStock)
 - 현재 확인된 공식 표면은 **매장 내 aisle/진열 위치**를 직접 주지 않을 수 있다.
 - `selStrPkupStck` 403 → `/api/auth/request` 재호출 후 Bearer를 새로 빌드해 재시도한다.
 - Bearer 재시도 후에도 401/403이면 재고 수량은 `retrievalStatus: "blocked"` 로 표시하고, `selPkupStr` 기반 `pickupEligibility`(픽업 가능 여부)만 보조 정보로 제공한다.
+- **package 없이 표면을 직접 호출하면 조용히 틀린다.** `SearchGoods`는 검색어 파라미터명이 틀려도 400이 아니라 200에 전체 카탈로그를 돌려준다. 검색어는 JSON 바디가 아니라 쿼리스트링 `searchTerm`으로 보내야 하고, `selStr`도 바디 키가 틀리면 무관한 매장 1건만 준다. 둘 다 실패가 성공처럼 보이므로 반드시 package를 경유한다.
 
 ## Notes
 

--- a/packages/k-skill-cli/test/snapshots/daiso-product-search.generic.md
+++ b/packages/k-skill-cli/test/snapshots/daiso-product-search.generic.md
@@ -44,7 +44,16 @@ Runtime mode: generic
 
 - 인터넷 연결
 - `node` 18+
-- 이 저장소의 `daiso-product-search` package 또는 동일 로직
+- `daiso-product-search` npm package
+
+설치:
+
+```bash
+npm install daiso-product-search
+```
+
+이 저장소에서 개발할 때는 루트에서 `npm install` 후 `packages/daiso-product-search`를 쓴다.
+package 설치가 막히면 표면을 직접 호출해 우회하지 말고 설치를 먼저 해결한다. 직접 호출은 실패가 성공처럼 보이는 응답을 준다(Failure modes 참고).
 
 ## Required inputs
 
@@ -179,6 +188,7 @@ console.log(result.pickupStock)
 - 현재 확인된 공식 표면은 **매장 내 aisle/진열 위치**를 직접 주지 않을 수 있다.
 - `selStrPkupStck` 403 → `/api/auth/request` 재호출 후 Bearer를 새로 빌드해 재시도한다.
 - Bearer 재시도 후에도 401/403이면 재고 수량은 `retrievalStatus: "blocked"` 로 표시하고, `selPkupStr` 기반 `pickupEligibility`(픽업 가능 여부)만 보조 정보로 제공한다.
+- **package 없이 표면을 직접 호출하면 조용히 틀린다.** `SearchGoods`는 검색어 파라미터명이 틀려도 400이 아니라 200에 전체 카탈로그를 돌려준다. 검색어는 JSON 바디가 아니라 쿼리스트링 `searchTerm`으로 보내야 하고, `selStr`도 바디 키가 틀리면 무관한 매장 1건만 준다. 둘 다 실패가 성공처럼 보이므로 반드시 package를 경유한다.
 
 ## Notes
 

--- a/packages/k-skill-cli/test/snapshots/market-kurly-search.dolshoi.md
+++ b/packages/k-skill-cli/test/snapshots/market-kurly-search.dolshoi.md
@@ -46,7 +46,15 @@ Runtime mode: dolshoi (CloakBrowser available)
 
 - 인터넷 연결
 - `node` 18+
-- 이 저장소의 `market-kurly-search` package 또는 동일 로직
+- `market-kurly-search` npm package
+
+설치:
+
+```bash
+npm install market-kurly-search
+```
+
+이 저장소에서 개발할 때는 루트에서 `npm install` 후 `packages/market-kurly-search`를 쓴다.
 
 ## Required inputs
 

--- a/packages/k-skill-cli/test/snapshots/market-kurly-search.generic.md
+++ b/packages/k-skill-cli/test/snapshots/market-kurly-search.generic.md
@@ -45,7 +45,15 @@ Runtime mode: generic
 
 - 인터넷 연결
 - `node` 18+
-- 이 저장소의 `market-kurly-search` package 또는 동일 로직
+- `market-kurly-search` npm package
+
+설치:
+
+```bash
+npm install market-kurly-search
+```
+
+이 저장소에서 개발할 때는 루트에서 `npm install` 후 `packages/market-kurly-search`를 쓴다.
 
 ## Required inputs
 


### PR DESCRIPTION
Closes #614

## 무엇을

`daiso-product-search`와 `market-kurly-search`의 Prerequisites를 `gongsijiga-search`, `saju-fortune`과 같은 하우스 스타일로 맞춰 `npm install <pkg>`를 명시합니다. daiso에는 표면 직접 호출 시의 조용한 실패를 Failure modes에 추가합니다.

## 왜

기존 문구 `- 이 저장소의 <pkg> package 또는 동일 로직`은 저장소 클론이 있는 기여자 기준입니다. 플러그인·CLI 사용자는 패키지가 npm에 발행돼 있다는 걸 알 수 없어 표면 직접 호출로 빠지고, **다이소는 그 경로에서 조용히 틀린 답을 냅니다.**

## 실측 근거

- `SearchGoods`에 파라미터명 14종(`keyword` `query` `q` `sq` `srchWord` `srchKwd` `word` `searchWord` `keywd` `kwd` `goodsNm` `pdNm` `text` `term`)을 JSON 바디로 시도 -> 전부 200 + 전체 카탈로그 30,205건. 실제 규격은 쿼리스트링 `searchTerm` (`packages/daiso-product-search/src/parse.js`의 `buildSearchGoodsParams`)
- `selStr`에 바디 키 5종 시도 -> 전부 무관한 매장 1건만 반환
- 패키지 경유 시 정상 동작 확인: 강남역2호점(`strCd=10224`) 리들샷 23종 재고 조회 성공
- market-kurly는 `instruction.md:50`의 URL 그대로 호출해 HTTP 200 확인 -> 조용한 오답 없음. Prerequisites 문구만 수정하고 Failure modes는 건드리지 않음

## 검증

```
node scripts/generate-skill-stubs.js --check           -> skill stubs are up to date (118 skills)
node scripts/sync-cli-skills.js --check                -> bundled skill files are exact (118 skills, 187 assets)
node scripts/migrate-cli-asset-instructions.js --check -> normalized (118 skills checked)
node scripts/generate-plugin-manifest.js --check       -> plugin.json is up to date (118 skills)
./scripts/validate-skills.sh                           -> skill layout looks valid
```

## 변경 파일

```
daiso-product-search/instruction.md
market-kurly-search/instruction.md
packages/k-skill-cli/skills/daiso-product-search/instruction.md   (sync:cli-skills 산출물)
packages/k-skill-cli/skills/market-kurly-search/instruction.md    (sync:cli-skills 산출물)
.changeset/fix-skill-package-prerequisites.md
```

패키지 소스는 건드리지 않았으므로 `daiso-product-search` / `market-kurly-search` 패키지 bump 없이 `@nomadamas/k-skill` patch만 넣었습니다. 이 changeset이 없으면 CLI가 재발행되지 않아 수정이 사용자에게 도달하지 않습니다 (CLI는 `src/assemble.js`에서 자기 npm 패키지 내부의 `skills/`만 읽습니다).
