### PR TITLE
fix: add structured coverage metadata for due diligence results

### DIFF
--- a/.changeset/wise-plums-cover.md
+++ b/.changeset/wise-plums-cover.md
@@ -1,0 +1,5 @@
+---
+"@nomadamas/k-skill": patch
+---
+
+Add structured coverage metadata to the NTS delinquency, G2B sanction, and FSC corporate-info skill results.

--- a/fsc-corporate-info/instruction.md
+++ b/fsc-corporate-info/instruction.md
@@ -48,7 +48,8 @@ npx -y @nomadamas/k-skill@0 exec fsc-corporate-info scripts/fsc_corporate_info.p
 - `400 bad_request`: 법인명을 주지 않음.
 - `503 upstream_not_configured`: 프록시 서버에 `DATA_GO_KR_API_KEY` 없음.
 - `502 upstream_forbidden`: 프록시 키가 15043184에 활용신청되지 않음.
-- 빈 결과: 법인명 불일치 — 표기를 바꿔 재시도.
+- `coverage`: 기업기본정보 데이터셋 범위, 법인명 후보 및 선택적 사업자번호 교차검증 기준, 제외 범위, 0건의 의미, 조회시각(`checked_at`)을 구조화해 제공한다.
+- 빈 결과: 이 데이터셋에서 입력 법인명 후보가 없음. 법인이 존재하지 않는다는 뜻이 아니며 표기 차이 가능성이 있다.
 
 ## Official surfaces
 

--- a/fsc-corporate-info/scripts/test_fsc_corporate_info.py
+++ b/fsc-corporate-info/scripts/test_fsc_corporate_info.py
@@ -1,0 +1,42 @@
+import unittest
+
+import fsc_corporate_info as subject
+
+
+class CoveragePassthroughTest(unittest.TestCase):
+    def test_zero_result_keeps_proxy_coverage(self):
+        payload = {
+            "candidate_count": 0,
+            "candidates": [],
+            "coverage": {"scope": "fsc-corporate-outline-dataset"},
+        }
+
+        response = subject.query_corp_outline("없는법인", read_json=lambda _request: payload)
+
+        self.assertIs(response, payload)
+        self.assertEqual(response["coverage"]["scope"], "fsc-corporate-outline-dataset")
+
+    def test_matched_result_keeps_proxy_coverage(self):
+        payload = {
+            "candidate_count": 1,
+            "candidates": [{"corpNm": "테스트"}],
+            "coverage": {
+                "match_basis": "corporate-name-candidates-with-optional-business-number-cross-check"
+            },
+        }
+
+        response = subject.query_corp_outline(
+            "테스트",
+            "123-45-67890",
+            read_json=lambda _request: payload,
+        )
+
+        self.assertIs(response, payload)
+        self.assertEqual(
+            response["coverage"]["match_basis"],
+            "corporate-name-candidates-with-optional-business-number-cross-check",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/g2b-sanctioned-supplier/instruction.md
+++ b/g2b-sanctioned-supplier/instruction.md
@@ -51,7 +51,8 @@ npx -y @nomadamas/k-skill@0 exec g2b-sanctioned-supplier scripts/g2b_sanctioned_
 - `400 bad_request`: 사업자번호가 10자리가 아님.
 - `503 upstream_not_configured`: 프록시 서버에 `DATA_GO_KR_API_KEY` 없음.
 - `502 upstream_forbidden`: 프록시 키가 15129466에 활용신청되지 않음.
-- `total_count = 0`: 조회시점 현재 유효한 제재 없음 (만료·미등록업체는 미제공임에 유의).
+- `coverage`: 현재 유효 제재 범위, 사업자번호 정확 일치 기준, 과거·미등록 제외 범위, 0건의 의미, 조회시각(`checked_at`)을 구조화해 제공한다.
+- `total_count = 0`: 조회시점 현재 유효한 제재가 조회되지 않음. 만료·해제된 과거 제재가 없다는 뜻은 아니다.
 
 ## Official surfaces
 

--- a/g2b-sanctioned-supplier/scripts/test_g2b_sanctioned_supplier.py
+++ b/g2b-sanctioned-supplier/scripts/test_g2b_sanctioned_supplier.py
@@ -1,0 +1,33 @@
+import unittest
+
+import g2b_sanctioned_supplier as subject
+
+
+class CoveragePassthroughTest(unittest.TestCase):
+    def test_zero_result_keeps_proxy_coverage(self):
+        payload = {
+            "total_count": 0,
+            "active_sanctions": [],
+            "coverage": {"scope": "currently-effective-g2b-sanctions"},
+        }
+
+        response = subject.query_sanctions("123-45-67890", read_json=lambda _request: payload)
+
+        self.assertIs(response, payload)
+        self.assertEqual(response["coverage"]["scope"], "currently-effective-g2b-sanctions")
+
+    def test_matched_result_keeps_proxy_coverage(self):
+        payload = {
+            "total_count": 1,
+            "active_sanctions": [{"bizno": "1234567890"}],
+            "coverage": {"match_basis": "exact-business-number"},
+        }
+
+        response = subject.query_sanctions("1234567890", read_json=lambda _request: payload)
+
+        self.assertIs(response, payload)
+        self.assertEqual(response["coverage"]["match_basis"], "exact-business-number")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/nts-tax-delinquency/instruction.md
+++ b/nts-tax-delinquency/instruction.md
@@ -47,7 +47,8 @@ npx -y @nomadamas/k-skill@0 exec nts-tax-delinquency scripts/nts_tax_delinquency
 ## Failure modes
 
 - `unavailable` + 안내: 상호 미입력, 네트워크 오류, 페이지 구조 변경 추정 — 수동 확인 URL 제공.
-- 0건: 두 명단 모두 매치 없음 (`match_count: 0`).
+- `coverage`: 조회한 공개 명단 범위, 상호·법인명 문자열 대조 기준, 제외 범위, 0건의 의미, 조회시각(`checked_at`)을 구조화해 제공한다.
+- 0건: 두 명단 모두 공개 명단에서 문자열 매치가 없음 (`match_count: 0`). 모든 국세 체납이 없다는 뜻은 아니다.
 
 ## Official surfaces
 

--- a/nts-tax-delinquency/scripts/nts_tax_delinquency.py
+++ b/nts-tax-delinquency/scripts/nts_tax_delinquency.py
@@ -36,6 +36,18 @@ INDIV_COLUMNS = ("no", "공개년도", "성명", "연령", "상호", "직업(업
 IDENTITY_NOTE = ("명단공개 자료에는 사업자등록번호가 수록되지 않아 입력 사업자번호와의 "
                  "동일성은 확인할 수 없다 — 상호·법인명 문자열 일치 후보의 공개 사실만 "
                  "나열하며, 동명 상호일 가능성은 사용자가 판단한다.")
+COVERAGE = {
+    "scope": "nts-high-amount-habitual-delinquent-disclosure",
+    "match_basis": "corporate-name-and-trade-name-string-match",
+    "exclusions": [
+        "명단공개 기준에 들지 않는 체납 및 비공개 체납",
+        "사업자등록번호 동일성 확인",
+    ],
+    "zero_result_meaning": (
+        "조회한 국세청 고액·상습체납자 공개 명단에서 법인명·상호 문자열 일치가 없다는 뜻이며, "
+        "모든 국세 체납이 없다는 뜻은 아니다."
+    ),
+}
 
 _HEADING_MARKER = "고액상습체납자"
 _ZERO_MARKER = "조회된 데이터가 없습니다"
@@ -50,13 +62,15 @@ def _now_iso() -> str:
 
 
 def _envelope(status: str, *, result: dict | None = None, note: str | None = None) -> dict:
+    looked_up_at = _now_iso()
     return {
         "source": SOURCE,
-        "looked_up_at": _now_iso(),
+        "looked_up_at": looked_up_at,
         "status": status,
         "result": result,
         "origin": "unauthenticated-public",
         "note": note,
+        "coverage": {**COVERAGE, "checked_at": looked_up_at} if status == "ok" else None,
     }
 
 

--- a/nts-tax-delinquency/scripts/test_nts_tax_delinquency.py
+++ b/nts-tax-delinquency/scripts/test_nts_tax_delinquency.py
@@ -1,0 +1,32 @@
+import unittest
+from unittest.mock import patch
+
+import nts_tax_delinquency as subject
+
+
+class CoverageTest(unittest.TestCase):
+    def test_zero_result_explains_disclosure_scope(self):
+        with patch.object(subject, "_search", side_effect=[[], []]):
+            response = subject.lookup("테스트상사")
+
+        self.assertEqual(response["status"], "ok")
+        self.assertEqual(response["result"]["corporate_list"]["match_count"], 0)
+        self.assertEqual(response["result"]["individual_list"]["match_count"], 0)
+        self.assertEqual(response["coverage"]["match_basis"], "corporate-name-and-trade-name-string-match")
+        self.assertTrue(response["coverage"]["zero_result_meaning"])
+        self.assertTrue(response["coverage"]["checked_at"])
+
+    def test_matched_result_keeps_same_coverage_contract(self):
+        corporate = [{"법인명": "테스트상사", "총체납액": "1억원"}]
+        individual = [{"상호": "테스트상사", "총체납액": "2억원"}]
+        with patch.object(subject, "_search", side_effect=[corporate, individual]):
+            response = subject.lookup("테스트상사")
+
+        self.assertEqual(response["result"]["corporate_list"]["matches"], corporate)
+        self.assertEqual(response["result"]["individual_list"]["matches"], individual)
+        self.assertEqual(response["coverage"]["scope"], "nts-high-amount-habitual-delinquent-disclosure")
+        self.assertIn("사업자등록번호 동일성 확인", response["coverage"]["exclusions"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/k-skill-cli/skills/fsc-corporate-info/instruction.md
+++ b/packages/k-skill-cli/skills/fsc-corporate-info/instruction.md
@@ -48,7 +48,8 @@ npx -y @nomadamas/k-skill@0 exec fsc-corporate-info scripts/fsc_corporate_info.p
 - `400 bad_request`: 법인명을 주지 않음.
 - `503 upstream_not_configured`: 프록시 서버에 `DATA_GO_KR_API_KEY` 없음.
 - `502 upstream_forbidden`: 프록시 키가 15043184에 활용신청되지 않음.
-- 빈 결과: 법인명 불일치 — 표기를 바꿔 재시도.
+- `coverage`: 기업기본정보 데이터셋 범위, 법인명 후보 및 선택적 사업자번호 교차검증 기준, 제외 범위, 0건의 의미, 조회시각(`checked_at`)을 구조화해 제공한다.
+- 빈 결과: 이 데이터셋에서 입력 법인명 후보가 없음. 법인이 존재하지 않는다는 뜻이 아니며 표기 차이 가능성이 있다.
 
 ## Official surfaces
 

--- a/packages/k-skill-cli/skills/fsc-corporate-info/scripts/test_fsc_corporate_info.py
+++ b/packages/k-skill-cli/skills/fsc-corporate-info/scripts/test_fsc_corporate_info.py
@@ -1,0 +1,42 @@
+import unittest
+
+import fsc_corporate_info as subject
+
+
+class CoveragePassthroughTest(unittest.TestCase):
+    def test_zero_result_keeps_proxy_coverage(self):
+        payload = {
+            "candidate_count": 0,
+            "candidates": [],
+            "coverage": {"scope": "fsc-corporate-outline-dataset"},
+        }
+
+        response = subject.query_corp_outline("없는법인", read_json=lambda _request: payload)
+
+        self.assertIs(response, payload)
+        self.assertEqual(response["coverage"]["scope"], "fsc-corporate-outline-dataset")
+
+    def test_matched_result_keeps_proxy_coverage(self):
+        payload = {
+            "candidate_count": 1,
+            "candidates": [{"corpNm": "테스트"}],
+            "coverage": {
+                "match_basis": "corporate-name-candidates-with-optional-business-number-cross-check"
+            },
+        }
+
+        response = subject.query_corp_outline(
+            "테스트",
+            "123-45-67890",
+            read_json=lambda _request: payload,
+        )
+
+        self.assertIs(response, payload)
+        self.assertEqual(
+            response["coverage"]["match_basis"],
+            "corporate-name-candidates-with-optional-business-number-cross-check",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/k-skill-cli/skills/g2b-sanctioned-supplier/instruction.md
+++ b/packages/k-skill-cli/skills/g2b-sanctioned-supplier/instruction.md
@@ -51,7 +51,8 @@ npx -y @nomadamas/k-skill@0 exec g2b-sanctioned-supplier scripts/g2b_sanctioned_
 - `400 bad_request`: 사업자번호가 10자리가 아님.
 - `503 upstream_not_configured`: 프록시 서버에 `DATA_GO_KR_API_KEY` 없음.
 - `502 upstream_forbidden`: 프록시 키가 15129466에 활용신청되지 않음.
-- `total_count = 0`: 조회시점 현재 유효한 제재 없음 (만료·미등록업체는 미제공임에 유의).
+- `coverage`: 현재 유효 제재 범위, 사업자번호 정확 일치 기준, 과거·미등록 제외 범위, 0건의 의미, 조회시각(`checked_at`)을 구조화해 제공한다.
+- `total_count = 0`: 조회시점 현재 유효한 제재가 조회되지 않음. 만료·해제된 과거 제재가 없다는 뜻은 아니다.
 
 ## Official surfaces
 

--- a/packages/k-skill-cli/skills/g2b-sanctioned-supplier/scripts/test_g2b_sanctioned_supplier.py
+++ b/packages/k-skill-cli/skills/g2b-sanctioned-supplier/scripts/test_g2b_sanctioned_supplier.py
@@ -1,0 +1,33 @@
+import unittest
+
+import g2b_sanctioned_supplier as subject
+
+
+class CoveragePassthroughTest(unittest.TestCase):
+    def test_zero_result_keeps_proxy_coverage(self):
+        payload = {
+            "total_count": 0,
+            "active_sanctions": [],
+            "coverage": {"scope": "currently-effective-g2b-sanctions"},
+        }
+
+        response = subject.query_sanctions("123-45-67890", read_json=lambda _request: payload)
+
+        self.assertIs(response, payload)
+        self.assertEqual(response["coverage"]["scope"], "currently-effective-g2b-sanctions")
+
+    def test_matched_result_keeps_proxy_coverage(self):
+        payload = {
+            "total_count": 1,
+            "active_sanctions": [{"bizno": "1234567890"}],
+            "coverage": {"match_basis": "exact-business-number"},
+        }
+
+        response = subject.query_sanctions("1234567890", read_json=lambda _request: payload)
+
+        self.assertIs(response, payload)
+        self.assertEqual(response["coverage"]["match_basis"], "exact-business-number")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/k-skill-cli/skills/nts-tax-delinquency/instruction.md
+++ b/packages/k-skill-cli/skills/nts-tax-delinquency/instruction.md
@@ -47,7 +47,8 @@ npx -y @nomadamas/k-skill@0 exec nts-tax-delinquency scripts/nts_tax_delinquency
 ## Failure modes
 
 - `unavailable` + 안내: 상호 미입력, 네트워크 오류, 페이지 구조 변경 추정 — 수동 확인 URL 제공.
-- 0건: 두 명단 모두 매치 없음 (`match_count: 0`).
+- `coverage`: 조회한 공개 명단 범위, 상호·법인명 문자열 대조 기준, 제외 범위, 0건의 의미, 조회시각(`checked_at`)을 구조화해 제공한다.
+- 0건: 두 명단 모두 공개 명단에서 문자열 매치가 없음 (`match_count: 0`). 모든 국세 체납이 없다는 뜻은 아니다.
 
 ## Official surfaces
 

--- a/packages/k-skill-cli/skills/nts-tax-delinquency/scripts/nts_tax_delinquency.py
+++ b/packages/k-skill-cli/skills/nts-tax-delinquency/scripts/nts_tax_delinquency.py
@@ -36,6 +36,18 @@ INDIV_COLUMNS = ("no", "공개년도", "성명", "연령", "상호", "직업(업
 IDENTITY_NOTE = ("명단공개 자료에는 사업자등록번호가 수록되지 않아 입력 사업자번호와의 "
                  "동일성은 확인할 수 없다 — 상호·법인명 문자열 일치 후보의 공개 사실만 "
                  "나열하며, 동명 상호일 가능성은 사용자가 판단한다.")
+COVERAGE = {
+    "scope": "nts-high-amount-habitual-delinquent-disclosure",
+    "match_basis": "corporate-name-and-trade-name-string-match",
+    "exclusions": [
+        "명단공개 기준에 들지 않는 체납 및 비공개 체납",
+        "사업자등록번호 동일성 확인",
+    ],
+    "zero_result_meaning": (
+        "조회한 국세청 고액·상습체납자 공개 명단에서 법인명·상호 문자열 일치가 없다는 뜻이며, "
+        "모든 국세 체납이 없다는 뜻은 아니다."
+    ),
+}
 
 _HEADING_MARKER = "고액상습체납자"
 _ZERO_MARKER = "조회된 데이터가 없습니다"
@@ -50,13 +62,15 @@ def _now_iso() -> str:
 
 
 def _envelope(status: str, *, result: dict | None = None, note: str | None = None) -> dict:
+    looked_up_at = _now_iso()
     return {
         "source": SOURCE,
-        "looked_up_at": _now_iso(),
+        "looked_up_at": looked_up_at,
         "status": status,
         "result": result,
         "origin": "unauthenticated-public",
         "note": note,
+        "coverage": {**COVERAGE, "checked_at": looked_up_at} if status == "ok" else None,
     }
 
 

--- a/packages/k-skill-cli/skills/nts-tax-delinquency/scripts/test_nts_tax_delinquency.py
+++ b/packages/k-skill-cli/skills/nts-tax-delinquency/scripts/test_nts_tax_delinquency.py
@@ -1,0 +1,32 @@
+import unittest
+from unittest.mock import patch
+
+import nts_tax_delinquency as subject
+
+
+class CoverageTest(unittest.TestCase):
+    def test_zero_result_explains_disclosure_scope(self):
+        with patch.object(subject, "_search", side_effect=[[], []]):
+            response = subject.lookup("테스트상사")
+
+        self.assertEqual(response["status"], "ok")
+        self.assertEqual(response["result"]["corporate_list"]["match_count"], 0)
+        self.assertEqual(response["result"]["individual_list"]["match_count"], 0)
+        self.assertEqual(response["coverage"]["match_basis"], "corporate-name-and-trade-name-string-match")
+        self.assertTrue(response["coverage"]["zero_result_meaning"])
+        self.assertTrue(response["coverage"]["checked_at"])
+
+    def test_matched_result_keeps_same_coverage_contract(self):
+        corporate = [{"법인명": "테스트상사", "총체납액": "1억원"}]
+        individual = [{"상호": "테스트상사", "총체납액": "2억원"}]
+        with patch.object(subject, "_search", side_effect=[corporate, individual]):
+            response = subject.lookup("테스트상사")
+
+        self.assertEqual(response["result"]["corporate_list"]["matches"], corporate)
+        self.assertEqual(response["result"]["individual_list"]["matches"], individual)
+        self.assertEqual(response["coverage"]["scope"], "nts-high-amount-habitual-delinquent-disclosure")
+        self.assertIn("사업자등록번호 동일성 확인", response["coverage"]["exclusions"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/k-skill-cli/test/snapshots/fsc-corporate-info.dolshoi.md
+++ b/packages/k-skill-cli/test/snapshots/fsc-corporate-info.dolshoi.md
@@ -66,7 +66,8 @@ npx -y @nomadamas/k-skill@0 exec fsc-corporate-info scripts/fsc_corporate_info.p
 - `400 bad_request`: 법인명을 주지 않음.
 - `503 upstream_not_configured`: 프록시 서버에 `DATA_GO_KR_API_KEY` 없음.
 - `502 upstream_forbidden`: 프록시 키가 15043184에 활용신청되지 않음.
-- 빈 결과: 법인명 불일치 — 표기를 바꿔 재시도.
+- `coverage`: 기업기본정보 데이터셋 범위, 법인명 후보 및 선택적 사업자번호 교차검증 기준, 제외 범위, 0건의 의미, 조회시각(`checked_at`)을 구조화해 제공한다.
+- 빈 결과: 이 데이터셋에서 입력 법인명 후보가 없음. 법인이 존재하지 않는다는 뜻이 아니며 표기 차이 가능성이 있다.
 
 ## Official surfaces
 

--- a/packages/k-skill-cli/test/snapshots/fsc-corporate-info.generic.md
+++ b/packages/k-skill-cli/test/snapshots/fsc-corporate-info.generic.md
@@ -66,7 +66,8 @@ npx -y @nomadamas/k-skill@0 exec fsc-corporate-info scripts/fsc_corporate_info.p
 - `400 bad_request`: 법인명을 주지 않음.
 - `503 upstream_not_configured`: 프록시 서버에 `DATA_GO_KR_API_KEY` 없음.
 - `502 upstream_forbidden`: 프록시 키가 15043184에 활용신청되지 않음.
-- 빈 결과: 법인명 불일치 — 표기를 바꿔 재시도.
+- `coverage`: 기업기본정보 데이터셋 범위, 법인명 후보 및 선택적 사업자번호 교차검증 기준, 제외 범위, 0건의 의미, 조회시각(`checked_at`)을 구조화해 제공한다.
+- 빈 결과: 이 데이터셋에서 입력 법인명 후보가 없음. 법인이 존재하지 않는다는 뜻이 아니며 표기 차이 가능성이 있다.
 
 ## Official surfaces
 

--- a/packages/k-skill-cli/test/snapshots/g2b-sanctioned-supplier.dolshoi.md
+++ b/packages/k-skill-cli/test/snapshots/g2b-sanctioned-supplier.dolshoi.md
@@ -69,7 +69,8 @@ npx -y @nomadamas/k-skill@0 exec g2b-sanctioned-supplier scripts/g2b_sanctioned_
 - `400 bad_request`: 사업자번호가 10자리가 아님.
 - `503 upstream_not_configured`: 프록시 서버에 `DATA_GO_KR_API_KEY` 없음.
 - `502 upstream_forbidden`: 프록시 키가 15129466에 활용신청되지 않음.
-- `total_count = 0`: 조회시점 현재 유효한 제재 없음 (만료·미등록업체는 미제공임에 유의).
+- `coverage`: 현재 유효 제재 범위, 사업자번호 정확 일치 기준, 과거·미등록 제외 범위, 0건의 의미, 조회시각(`checked_at`)을 구조화해 제공한다.
+- `total_count = 0`: 조회시점 현재 유효한 제재가 조회되지 않음. 만료·해제된 과거 제재가 없다는 뜻은 아니다.
 
 ## Official surfaces
 

--- a/packages/k-skill-cli/test/snapshots/g2b-sanctioned-supplier.generic.md
+++ b/packages/k-skill-cli/test/snapshots/g2b-sanctioned-supplier.generic.md
@@ -69,7 +69,8 @@ npx -y @nomadamas/k-skill@0 exec g2b-sanctioned-supplier scripts/g2b_sanctioned_
 - `400 bad_request`: 사업자번호가 10자리가 아님.
 - `503 upstream_not_configured`: 프록시 서버에 `DATA_GO_KR_API_KEY` 없음.
 - `502 upstream_forbidden`: 프록시 키가 15129466에 활용신청되지 않음.
-- `total_count = 0`: 조회시점 현재 유효한 제재 없음 (만료·미등록업체는 미제공임에 유의).
+- `coverage`: 현재 유효 제재 범위, 사업자번호 정확 일치 기준, 과거·미등록 제외 범위, 0건의 의미, 조회시각(`checked_at`)을 구조화해 제공한다.
+- `total_count = 0`: 조회시점 현재 유효한 제재가 조회되지 않음. 만료·해제된 과거 제재가 없다는 뜻은 아니다.
 
 ## Official surfaces
 

--- a/packages/k-skill-cli/test/snapshots/nts-tax-delinquency.dolshoi.md
+++ b/packages/k-skill-cli/test/snapshots/nts-tax-delinquency.dolshoi.md
@@ -65,7 +65,8 @@ npx -y @nomadamas/k-skill@0 exec nts-tax-delinquency scripts/nts_tax_delinquency
 ## Failure modes
 
 - `unavailable` + 안내: 상호 미입력, 네트워크 오류, 페이지 구조 변경 추정 — 수동 확인 URL 제공.
-- 0건: 두 명단 모두 매치 없음 (`match_count: 0`).
+- `coverage`: 조회한 공개 명단 범위, 상호·법인명 문자열 대조 기준, 제외 범위, 0건의 의미, 조회시각(`checked_at`)을 구조화해 제공한다.
+- 0건: 두 명단 모두 공개 명단에서 문자열 매치가 없음 (`match_count: 0`). 모든 국세 체납이 없다는 뜻은 아니다.
 
 ## Official surfaces
 

--- a/packages/k-skill-cli/test/snapshots/nts-tax-delinquency.generic.md
+++ b/packages/k-skill-cli/test/snapshots/nts-tax-delinquency.generic.md
@@ -64,7 +64,8 @@ npx -y @nomadamas/k-skill@0 exec nts-tax-delinquency scripts/nts_tax_delinquency
 ## Failure modes
 
 - `unavailable` + 안내: 상호 미입력, 네트워크 오류, 페이지 구조 변경 추정 — 수동 확인 URL 제공.
-- 0건: 두 명단 모두 매치 없음 (`match_count: 0`).
+- `coverage`: 조회한 공개 명단 범위, 상호·법인명 문자열 대조 기준, 제외 범위, 0건의 의미, 조회시각(`checked_at`)을 구조화해 제공한다.
+- 0건: 두 명단 모두 공개 명단에서 문자열 매치가 없음 (`match_count: 0`). 모든 국세 체납이 없다는 뜻은 아니다.
 
 ## Official surfaces
 

--- a/packages/k-skill-proxy/src/fsc-corp.js
+++ b/packages/k-skill-proxy/src/fsc-corp.js
@@ -137,6 +137,18 @@ async function fetchFscCorpOutline({ corpNm, bno = null, serviceKey, fetchImpl =
     query_corp_nm: corpNm,
     candidate_count: items.length,
     candidates: items,
+    coverage: {
+      scope: "fsc-corporate-outline-dataset",
+      match_basis: "corporate-name-candidates-with-optional-business-number-cross-check",
+      exclusions: [
+        "records-outside-the-fsc-corporate-outline-dataset",
+        "candidates-missed-by-corporate-name-variation-or-mismatch",
+        "business-number-identity-check-when-upstream-bzno-is-absent",
+      ],
+      zero_result_meaning:
+        "입력한 법인명으로 이 데이터셋에서 후보가 조회되지 않았다는 뜻이며, 법인이 존재하지 않는다는 뜻이 아니다.",
+      checked_at: new Date().toISOString(),
+    },
     b_no_cross_check: {
       checked: Boolean(hasBzno && bno),
       input_b_no: bno,

--- a/packages/k-skill-proxy/src/g2b-sanction.js
+++ b/packages/k-skill-proxy/src/g2b-sanction.js
@@ -121,6 +121,17 @@ async function fetchG2bSanctions({ bizno, serviceKey, fetchImpl = global.fetch }
     bizno,
     total_count: extracted.totalCount,
     active_sanctions: extracted.items,
+    coverage: {
+      scope: "currently-effective-g2b-sanctions",
+      match_basis: "exact-business-number",
+      exclusions: [
+        "expired-or-lifted-sanctions",
+        "sanctions-against-suppliers-or-individuals-not-registered-in-g2b",
+      ],
+      zero_result_meaning:
+        "조회 시점에 해당 사업자등록번호로 현재 유효한 제재가 조회되지 않았다는 뜻이며, 과거 만료·해제 제재가 없다는 뜻은 아니다.",
+      checked_at: new Date().toISOString(),
+    },
     match_basis:
       "Exact business-number match (inqryDiv=1) — the list of sanctions in force at query time (first 100). Expired/lifted sanctions and non-registered suppliers are not provided by the upstream.",
   };

--- a/packages/k-skill-proxy/test/server.test.js
+++ b/packages/k-skill-proxy/test/server.test.js
@@ -6939,12 +6939,43 @@ test("fsc corp-outline route returns name-matched candidates and cross-checks bz
   assert.equal(body.candidate_count, 1);
   assert.equal(body.b_no_cross_check.checked, true);
   assert.equal(body.b_no_cross_check.matched_candidates.length, 1);
+  assert.equal(body.coverage.scope, "fsc-corporate-outline-dataset");
+  assert.equal(body.coverage.match_basis, "corporate-name-candidates-with-optional-business-number-cross-check");
+  assert.ok(body.coverage.checked_at);
   const cached = await app.inject({
     method: "GET",
     url: "/v1/fsc/corp-outline?name=" + encodeURIComponent("테스트") + "&b_no=1234567890"
   });
   assert.equal(cached.json().proxy.cache.hit, true);
   assert.equal(fetchCalls, 1);
+});
+
+test("fsc corp-outline zero result explains dataset and naming limits", async (t) => {
+  const originalFetch = global.fetch;
+  global.fetch = async () => new Response(
+    JSON.stringify({
+      response: {
+        header: { resultCode: "00", resultMsg: "NORMAL SERVICE." },
+        body: { items: "" }
+      }
+    }),
+    { status: 200, headers: { "content-type": "application/json" } }
+  );
+  const app = buildServer({ env: { DATA_GO_KR_API_KEY: "data-go-key" } });
+  t.after(async () => {
+    global.fetch = originalFetch;
+    await app.close();
+  });
+
+  const res = await app.inject({
+    method: "GET",
+    url: "/v1/fsc/corp-outline?name=" + encodeURIComponent("없는법인")
+  });
+  const body = res.json();
+  assert.equal(res.statusCode, 200);
+  assert.equal(body.candidate_count, 0);
+  assert.ok(body.coverage.zero_result_meaning);
+  assert.ok(body.coverage.exclusions.includes("candidates-missed-by-corporate-name-variation-or-mismatch"));
 });
 
 test("fsc corp-outline route maps upstream 403 to a 502 forbidden error", async (t) => {
@@ -7004,6 +7035,9 @@ test("g2b sanctioned-supplier route returns active sanctions and uses capital-S 
   assert.equal(res.statusCode, 200);
   assert.equal(body.total_count, 1);
   assert.equal(body.active_sanctions[0].bizNm, "갑");
+  assert.equal(body.coverage.scope, "currently-effective-g2b-sanctions");
+  assert.equal(body.coverage.match_basis, "exact-business-number");
+  assert.ok(body.coverage.checked_at);
   assert.match(seenUrls[0], /ServiceKey=data-go-key/);
   assert.match(seenUrls[0], /inqryDiv=1/);
 
@@ -7018,6 +7052,31 @@ test("g2b sanctioned-supplier route returns active sanctions and uses capital-S 
   const missing = await noKey.inject({ method: "GET", url: "/v1/g2b/sanctioned-supplier?bizno=1234567890" });
   assert.equal(missing.statusCode, 503);
 
+});
+
+test("g2b sanctioned-supplier zero result explains excluded historical sanctions", async (t) => {
+  const originalFetch = global.fetch;
+  global.fetch = async () => new Response(
+    JSON.stringify({
+      response: {
+        header: { resultCode: "00" },
+        body: { items: "", totalCount: 0 }
+      }
+    }),
+    { status: 200, headers: { "content-type": "application/json" } }
+  );
+  const app = buildServer({ env: { DATA_GO_KR_API_KEY: "data-go-key" } });
+  t.after(async () => {
+    global.fetch = originalFetch;
+    await app.close();
+  });
+
+  const res = await app.inject({ method: "GET", url: "/v1/g2b/sanctioned-supplier?bizno=1234567890" });
+  const body = res.json();
+  assert.equal(res.statusCode, 200);
+  assert.equal(body.total_count, 0);
+  assert.ok(body.coverage.zero_result_meaning);
+  assert.ok(body.coverage.exclusions.includes("expired-or-lifted-sanctions"));
 });
 
 test("korean-law search endpoint proxies law.go.kr with the server OC and browser headers", async (t) => {


### PR DESCRIPTION
## Summary
- add stable `coverage` metadata to NTS delinquency, G2B sanctions, and FSC corporate outline JSON results
- preserve existing free-form fields for compatibility and align skill instructions, bundled CLI assets, and snapshots
- add zero-result and matched-result regression coverage for helpers and proxy routes

## Verification
- `npm run ci`
- manual QA through the bundled CLI and direct helper/proxy drivers for zero, match, help, and invalid-input paths

Closes #472