### PR TITLE
fix(proxy): classify MOLIT semantic errors

### DIFF
--- a/packages/k-skill-proxy/src/molit.js
+++ b/packages/k-skill-proxy/src/molit.js
@@ -80,6 +80,25 @@ function parseXmlItems(xmlText) {
   if (resultCode !== "000") {
     const msgMatch = xmlText.match(/<resultMsg>([^<]*)<\/resultMsg>/);
     const resultMsg = msgMatch ? msgMatch[1].trim() : `API error code ${resultCode}`;
+    if (resultCode === "22") {
+      return {
+        error: "upstream_quota_exceeded",
+        message: resultMsg,
+        status_code: 503,
+        retry_after: 3600,
+        upstream_code: resultCode
+      };
+    }
+
+    if (["20", "30", "31"].includes(resultCode)) {
+      return {
+        error: "upstream_configuration_error",
+        message: resultMsg,
+        status_code: 502,
+        upstream_code: resultCode
+      };
+    }
+
     return { error: `molit_api_${resultCode}`, message: resultMsg };
   }
 

--- a/packages/k-skill-proxy/src/server.js
+++ b/packages/k-skill-proxy/src/server.js
@@ -3645,7 +3645,19 @@ function buildServer({ env = process.env, provider = null, now = () => new Date(
     });
 
     if (result.error) {
-      reply.code(502);
+      const logUpstreamError = result.error === "upstream_configuration_error"
+        ? request.log.error.bind(request.log)
+        : request.log.warn.bind(request.log);
+      logUpstreamError({
+        route: "/v1/real-estate/:assetType/:dealType",
+        upstreamError: result.error,
+        upstreamMessage: result.message,
+        upstreamCode: result.upstream_code
+      }, "real estate upstream error");
+      reply.code(result.status_code || 502);
+      if (result.retry_after) {
+        reply.header("retry-after", String(result.retry_after));
+      }
       return {
         ...result,
         proxy: {
@@ -3734,6 +3746,11 @@ function buildServer({ env = process.env, provider = null, now = () => new Date(
         serviceKey: config.molitApiKey
       });
     } catch (error) {
+      request.log.warn({
+        route: "/v1/korean-stock/search",
+        upstreamError: error.code || "proxy_error",
+        upstreamMessage: error.message
+      }, "KRX upstream error");
       reply.code(error.statusCode && error.statusCode >= 400 ? error.statusCode : 502);
       return {
         error: error.upstreamCode ? "upstream_error" : "proxy_error",
@@ -3917,6 +3934,11 @@ function buildServer({ env = process.env, provider = null, now = () => new Date(
         filters: normalized
       });
     } catch (error) {
+      request.log.warn({
+        route: "/v1/korean-stock/base-info",
+        upstreamError: error.code || "proxy_error",
+        upstreamMessage: error.message
+      }, "KRX upstream error");
       reply.code(error.statusCode && error.statusCode >= 400 ? error.statusCode : 502);
       return {
         error: error.code || "proxy_error",
@@ -3998,6 +4020,11 @@ function buildServer({ env = process.env, provider = null, now = () => new Date(
         filters: normalized
       });
     } catch (error) {
+      request.log.warn({
+        route: "/v1/korean-stock/trade-info",
+        upstreamError: error.code || "proxy_error",
+        upstreamMessage: error.message
+      }, "KRX upstream error");
       reply.code(error.statusCode && error.statusCode >= 400 ? error.statusCode : 502);
       return {
         error: error.code || "proxy_error",

--- a/packages/k-skill-proxy/test/server.test.js
+++ b/packages/k-skill-proxy/test/server.test.js
@@ -43,6 +43,7 @@ const {
   proxySeoulCityDataRequest,
   proxySeoulSubwayRequest
 } = require("../src/server");
+const { parseXmlItems } = require("../src/molit");
 const { resolveEducationOfficeFromNaturalLanguage } = require("../src/neis-office-codes");
 
 test("makeCacheKey requires a non-empty route to prevent cross-route collisions", () => {
@@ -4354,6 +4355,63 @@ test("real estate transaction endpoint retries a single upstream 502 then succee
   assert.equal(response.statusCode, 200);
   assert.equal(fetchCalls, 2);
   assert.equal(response.json().items[0].name, "래미안");
+});
+
+test("MOLIT resultCode 22 is a non-retryable quota error", () => {
+  const result = parseXmlItems(`
+    <response>
+      <header>
+        <resultCode>22</resultCode>
+        <resultMsg>LIMITED NUMBER OF SERVICE REQUESTS EXCEEDS</resultMsg>
+      </header>
+    </response>
+  `);
+
+  assert.deepEqual(result, {
+    error: "upstream_quota_exceeded",
+    message: "LIMITED NUMBER OF SERVICE REQUESTS EXCEEDS",
+    status_code: 503,
+    retry_after: 3600,
+    upstream_code: "22"
+  });
+});
+
+test("real estate quota response returns 503 with Retry-After", async (t) => {
+  const originalFetch = global.fetch;
+  let fetchCalls = 0;
+  global.fetch = async () => {
+    fetchCalls += 1;
+    return new Response(`
+      <response>
+        <header>
+          <resultCode>22</resultCode>
+          <resultMsg>LIMITED NUMBER OF SERVICE REQUESTS EXCEEDS</resultMsg>
+        </header>
+      </response>
+    `, {
+      status: 200,
+      headers: { "content-type": "text/xml;charset=UTF-8" }
+    });
+  };
+
+  const app = buildServer({
+    env: { DATA_GO_KR_API_KEY: "test-key" }
+  });
+
+  t.after(async () => {
+    global.fetch = originalFetch;
+    await app.close();
+  });
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/v1/real-estate/apartment/trade?lawd_cd=11680&deal_ymd=202403"
+  });
+
+  assert.equal(response.statusCode, 503);
+  assert.equal(response.headers["retry-after"], "3600");
+  assert.equal(response.json().error, "upstream_quota_exceeded");
+  assert.equal(fetchCalls, 1);
 });
 
 test("real estate transaction endpoint caches successful responses", async (t) => {


### PR DESCRIPTION
## Summary
- map MOLIT resultCode 22 to `503 upstream_quota_exceeded` with `Retry-After: 3600`
- classify MOLIT key/application errors separately from transient failures
- log real-estate and KRX upstream error attribution without exposing credentials

## TDD
- added failing unit coverage for resultCode 22 mapping
- added failing HTTP integration coverage for 503 + Retry-After and single upstream call
- observed both tests fail before implementation and pass after implementation

## Verification
- `node --test packages/k-skill-proxy/test/server.test.js` (210/210 pass)
- `npm run lint --workspace k-skill-proxy`
- local proxy `GET /health` -> 200
- local proxy invalid real-estate query -> 400
- local proxy live MOLIT request reached upstream but timed out after 20s -> 502; structured `real estate upstream error` warning observed
- production `https://k-skill-proxy.nomadamas.org/health` -> 200
- root `npm run ci` reached tests; unrelated local ignored `tools/k-skill-qa-bot` directory triggers the existing retired-daemon assertion. The changed proxy test/lint suites are clean.

Closes #603