### PR TITLE
fix(proxy): attribute AirKorea operation failures

### DIFF
--- a/packages/k-skill-proxy/src/server.js
+++ b/packages/k-skill-proxy/src/server.js
@@ -1532,6 +1532,14 @@ async function proxyAirKoreaRequest({ service, operation, query, serviceKey, fet
     error.code = "upstream_fetch_failed";
     throw error;
   }
+  if (response.status === 403) {
+    const error = new Error(`AirKorea upstream returned HTTP 403 for ${service}/${operation}.`);
+    error.statusCode = 403;
+    error.code = "upstream_forbidden";
+    error.service = service;
+    error.operation = operation;
+    throw error;
+  }
   const body = await response.text();
   return {
     statusCode: response.status,
@@ -2355,12 +2363,25 @@ function buildServer({ env = process.env, provider = null, now = () => new Date(
 
   app.get("/B552584/:service/:operation", async (request, reply) => {
     const { service, operation } = request.params;
-    const upstream = await proxyAirKoreaRequest({
-      service,
-      operation,
-      query: request.query,
-      serviceKey: config.airKoreaApiKey
-    });
+    let upstream;
+    try {
+      upstream = await proxyAirKoreaRequest({
+        service,
+        operation,
+        query: request.query,
+        serviceKey: config.airKoreaApiKey
+      });
+    } catch (error) {
+      request.log.error({
+        route: "/B552584/:service/:operation",
+        service,
+        operation,
+        upstreamStatus: error.statusCode || 502,
+        upstreamError: error.code || "upstream_error",
+        upstreamMessage: error.message
+      }, "AirKorea upstream error");
+      throw error;
+    }
 
     reply.code(upstream.statusCode);
     reply.header("content-type", upstream.contentType);

--- a/packages/k-skill-proxy/test/server.test.js
+++ b/packages/k-skill-proxy/test/server.test.js
@@ -2950,6 +2950,26 @@ test("proxyAirKoreaRequest redacts service keys echoed with URLSearchParams enco
   }
 });
 
+test("proxyAirKoreaRequest preserves AirKorea 403 operation context", async () => {
+  await assert.rejects(
+    () => proxyAirKoreaRequest({
+      service: "ArpltnInforInqireSvc",
+      operation: "getMsrstnAcctoRltmMesureDnsty",
+      query: { returnType: "json", stationName: "강남구" },
+      serviceKey: "airkorea-key",
+      fetchImpl: async () => new Response("forbidden", { status: 403 })
+    }),
+    (error) => {
+      assert.equal(error.statusCode, 403);
+      assert.equal(error.code, "upstream_forbidden");
+      assert.equal(error.service, "ArpltnInforInqireSvc");
+      assert.equal(error.operation, "getMsrstnAcctoRltmMesureDnsty");
+      assert.match(error.message, /getMsrstnAcctoRltmMesureDnsty/);
+      return true;
+    }
+  );
+});
+
 test("AirKorea fetch rejections do not expose credential-bearing URLs", async (t) => {
   const originalFetch = global.fetch;
   global.fetch = async (url) => {


### PR DESCRIPTION
## Summary
- preserve AirKorea 403 operation/service context in structured errors
- log the exact AirKorea service and operation on passthrough failures
- keep credentials out of error messages and responses

## TDD
- added regression coverage for 403 operation attribution
- confirmed the new test failed before implementation and passed after

## Verification
- `node --test packages/k-skill-proxy/test/server.test.js` (211/211 pass)
- `npm run lint --workspace k-skill-proxy`
- local proxy health -> 200
- local proxy without local AirKorea key -> 503 (safe configuration response)
- gpu01 live E2E: station lookup -> HTTP 403 `SERVICE_KEY_IS_NOT_REGISTERED_ERROR`; measurement lookup -> HTTP 200/resultCode 00

## Operator confirmation required
- [ ] Confirm the gpu01 `AIR_KOREA_OPEN_API_KEY` belongs to the data.go.kr account that applied for `MsrstnInfoInqireSvc` and `ArpltnInforInqireSvc`.
- [ ] Confirm all operations used by `airkorea.js` are approved and synchronized.
- [ ] After correction, observe gpu01 proxy logs for one week and confirm AirKorea 403s converge to zero.

This PR intentionally remains draft until the operator checks above are complete.

Closes #605