### PR TITLE
feat(proxy): add error watchdog dry run

### DIFF
--- a/docs/deploy-k-skill-proxy.md
+++ b/docs/deploy-k-skill-proxy.md
@@ -67,6 +67,32 @@ systemctl --user status k-skill-proxy.service
 systemctl --user status k-skill-proxy-tunnel.service
 ```
 
+## Proxy error watchdog
+
+The watchdog reads only new structured `routeUsage` lines from `proxy.log`,
+aggregates `route × statusCode × errorCode`, and requires two consecutive
+hourly threshold breaches before acting. It is dry-run by default:
+
+```bash
+node scripts/proxy-error-watchdog.mjs
+node scripts/proxy-error-watchdog.mjs --apply
+```
+
+`--apply` requires an authenticated `gh` CLI with `issues:write` permission and
+the repository label `auto-proxy-watchdog`. It creates one open issue per
+fingerprint, updates an existing issue instead of duplicating it, and limits
+comments to once per UTC day.
+
+Recommended gpu01 cron after a one-week dry-run tuning period:
+
+```cron
+5 * * * * /data/home/jeffrey/apps/k-skill-proxy-repo/scripts/proxy-error-watchdog.sh >> /data/home/jeffrey/apps/k-skill-proxy/watchdog.log 2>&1
+```
+
+After thresholds are approved, add `--apply`. Runtime paths can be overridden
+with `KSKILL_PROXY_LOG_FILE` and `KSKILL_PROXY_WATCHDOG_STATE`. The state file
+stores the byte offset, consecutive-window counters, and comment timestamps.
+
 Verify the trust-proxy setting without printing the rest of the secret-bearing env file:
 
 ```bash

--- a/scripts/proxy-error-watchdog.mjs
+++ b/scripts/proxy-error-watchdog.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+export function parseRouteUsageLine(line) {
+  try {
+    const value = JSON.parse(line);
+    if (!value.routeUsage || !value.route || Number(value.statusCode) < 400) return null;
+    return {
+      route: value.route,
+      statusCode: Number(value.statusCode),
+      errorCode: value.errorCode || null,
+      message: value.msg || null
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function aggregateRouteUsage(lines) {
+  const counts = new Map();
+  for (const line of lines) {
+    const entry = parseRouteUsageLine(line);
+    if (!entry) continue;
+    const key = `${entry.route}|${entry.statusCode}|${entry.errorCode || ""}`;
+    const current = counts.get(key) || {
+      route: entry.route,
+      statusCode: entry.statusCode,
+      errorCode: entry.errorCode,
+      count: 0
+    };
+    current.count += 1;
+    counts.set(key, current);
+  }
+  return [...counts.values()].sort((a, b) => b.count - a.count || a.route.localeCompare(b.route));
+}
+
+export function fingerprint(entry) {
+  return `${entry.route}|${entry.statusCode}|${entry.errorCode || ""}`;
+}
+
+export function thresholdFor(statusCode) {
+  if (statusCode >= 500) return 500;
+  if (statusCode === 400) return 300;
+  return Number.POSITIVE_INFINITY;
+}
+
+export function findAlerts(entries) {
+  return entries.filter((entry) => entry.count > thresholdFor(entry.statusCode));
+}
+
+export function mergeState(state, alerts, windowId) {
+  const next = { ...state, fingerprints: { ...(state.fingerprints || {}) } };
+  for (const alert of alerts) {
+    const key = fingerprint(alert);
+    const previous = next.fingerprints[key] || { consecutiveWindows: 0, lastWindow: null };
+    next.fingerprints[key] = {
+      consecutiveWindows: previous.lastWindow === windowId - 1 ? previous.consecutiveWindows + 1 : 1,
+      lastWindow: windowId
+    };
+  }
+  next.lastWindow = windowId;
+  return next;
+}
+
+export function actionableAlerts(state, alerts, windowId) {
+  return alerts.filter((alert) => {
+    const record = state.fingerprints?.[fingerprint(alert)];
+    return record && record.lastWindow === windowId && record.consecutiveWindows >= 2;
+  });
+}
+
+export function shouldComment(lastCommentAt, nowIso) {
+  if (!lastCommentAt) return true;
+  return lastCommentAt.slice(0, 10) !== nowIso.slice(0, 10);
+}
+
+export function renderIssueBody(alerts, windowStart, windowEnd) {
+  const rows = alerts
+    .map((entry) => `| \`${entry.route}\` | ${entry.statusCode} | ${entry.errorCode || "-"} | ${entry.count} |`)
+    .join("\n");
+  return [
+    "## Proxy error watchdog alert",
+    "",
+    `Window: ${windowStart} - ${windowEnd}`,
+    "",
+    "| Route | Status | Error code | Count |",
+    "| --- | ---: | --- | ---: |",
+    rows,
+    "",
+    "This issue was generated after the same fingerprint exceeded its threshold in two consecutive windows."
+  ].join("\n");
+}
+
+function readLinesSince(file, offset) {
+  if (!fs.existsSync(file)) return { lines: [], offset: 0 };
+  const buffer = fs.readFileSync(file);
+  const nextOffset = buffer.length;
+  const safeOffset = offset > buffer.length ? 0 : offset;
+  return { lines: buffer.subarray(safeOffset).toString("utf8").split(/\r?\n/), offset: nextOffset };
+}
+
+function runGh(args) {
+  return execFileSync("gh", args, { encoding: "utf8", stdio: ["ignore", "pipe", "inherit"] }).trim();
+}
+
+function applyAlerts(alerts, body, label, state, nowIso) {
+  for (const alert of alerts) {
+    const title = `[proxy-watchdog] ${fingerprint(alert)}`;
+    const existing = runGh(["issue", "list", "--state", "open", "--label", label, "--search", `"${title}" in:title`, "--json", "number,title"]);
+    const issues = existing ? JSON.parse(existing) : [];
+    if (issues.length > 0) {
+      const key = fingerprint(alert);
+      const lastCommentAt = state.comments?.[key] || null;
+      if (shouldComment(lastCommentAt, nowIso)) {
+        runGh(["issue", "comment", String(issues[0].number), "--body", body]);
+        state.comments = { ...(state.comments || {}), [key]: nowIso };
+      }
+    } else {
+      runGh(["issue", "create", "--title", title, "--label", label, "--body", body]);
+    }
+  }
+}
+
+export function run({ logFile, stateFile, windowId, dryRun = true, now = new Date() }) {
+  const state = fs.existsSync(stateFile) ? JSON.parse(fs.readFileSync(stateFile, "utf8")) : {};
+  const offset = Number(state.logOffset || 0);
+  const read = readLinesSince(logFile, offset);
+  const entries = aggregateRouteUsage(read.lines);
+  const alerts = findAlerts(entries);
+  const nextState = mergeState(state, alerts, windowId);
+  const actionable = actionableAlerts(nextState, alerts, windowId);
+  nextState.logOffset = read.offset;
+  nextState.updatedAt = now.toISOString();
+  fs.mkdirSync(path.dirname(stateFile), { recursive: true });
+  fs.writeFileSync(stateFile, `${JSON.stringify(nextState, null, 2)}\n`);
+  const body = renderIssueBody(actionable, new Date(windowId * 3600000).toISOString(), now.toISOString());
+  if (!dryRun && actionable.length > 0) {
+    applyAlerts(actionable, body, "auto-proxy-watchdog", nextState, now.toISOString());
+    fs.writeFileSync(stateFile, `${JSON.stringify(nextState, null, 2)}\n`);
+  }
+  return { entries, alerts, actionable, body, state: nextState };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const args = new Set(process.argv.slice(2));
+  const logFile = process.env.KSKILL_PROXY_LOG_FILE || `${os.homedir()}/apps/k-skill-proxy/proxy.log`;
+  const stateFile = process.env.KSKILL_PROXY_WATCHDOG_STATE || `${os.homedir()}/apps/k-skill-proxy/watchdog-state.json`;
+  const windowId = Math.floor(Date.now() / 3600000);
+  const result = run({ logFile, stateFile, windowId, dryRun: !args.has("--apply") });
+  process.stdout.write(`${JSON.stringify({ alerts: result.alerts, actionable: result.actionable, dryRun: !args.has("--apply") })}\n`);
+}

--- a/scripts/proxy-error-watchdog.sh
+++ b/scripts/proxy-error-watchdog.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+exec node "$SCRIPT_DIR/proxy-error-watchdog.mjs" "$@"

--- a/scripts/proxy-error-watchdog.test.mjs
+++ b/scripts/proxy-error-watchdog.test.mjs
@@ -1,0 +1,91 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  actionableAlerts,
+  aggregateRouteUsage,
+  findAlerts,
+  fingerprint,
+  mergeState,
+  parseRouteUsageLine,
+  renderIssueBody,
+  run,
+  shouldComment,
+  thresholdFor
+} from "./proxy-error-watchdog.mjs";
+
+test("parses only structured error route usage lines", () => {
+  assert.deepEqual(parseRouteUsageLine(JSON.stringify({
+    routeUsage: true,
+    route: "/v1/example",
+    statusCode: 503,
+    errorCode: "upstream_error",
+    msg: "upstream failed"
+  })), {
+    route: "/v1/example",
+    statusCode: 503,
+    errorCode: "upstream_error",
+    message: "upstream failed"
+  });
+  assert.equal(parseRouteUsageLine("not json"), null);
+  assert.equal(parseRouteUsageLine(JSON.stringify({ routeUsage: true, route: "/health", statusCode: 200 })), null);
+});
+
+test("aggregates route and status fingerprints", () => {
+  const lines = [
+    ...Array.from({ length: 501 }, () => JSON.stringify({ routeUsage: true, route: "/v1/a", statusCode: 502, errorCode: "upstream_error" })),
+    ...Array.from({ length: 301 }, () => JSON.stringify({ routeUsage: true, route: "/v1/b", statusCode: 400, errorCode: "bad_request" }))
+  ];
+  const entries = aggregateRouteUsage(lines);
+  assert.equal(entries[0].count, 501);
+  assert.equal(findAlerts(entries).length, 2);
+  assert.equal(thresholdFor(404), Infinity);
+  assert.equal(fingerprint(entries[0]), "/v1/a|502|upstream_error");
+});
+
+test("requires two consecutive windows before action", () => {
+  const alert = { route: "/v1/a", statusCode: 502, errorCode: "upstream_error", count: 501 };
+  const first = mergeState({}, [alert], 10);
+  assert.deepEqual(actionableAlerts(first, [alert], 10), []);
+  const second = mergeState(first, [alert], 11);
+  assert.equal(actionableAlerts(second, [alert], 11).length, 1);
+});
+
+test("renders actionable issue body with fingerprint details", () => {
+  const body = renderIssueBody([
+    { route: "/v1/a", statusCode: 502, errorCode: "upstream_error", count: 501 }
+  ], "2026-08-21T00:00:00.000Z", "2026-08-21T01:00:00.000Z");
+  assert.match(body, /Proxy error watchdog alert/);
+  assert.match(body, /upstream_error/);
+  assert.match(body, /501/);
+});
+
+test("dedupe comments are limited to once per UTC day", () => {
+  assert.equal(shouldComment(null, "2026-08-21T01:00:00.000Z"), true);
+  assert.equal(shouldComment("2026-08-21T00:10:00.000Z", "2026-08-21T23:00:00.000Z"), false);
+  assert.equal(shouldComment("2026-08-21T23:00:00.000Z", "2026-08-22T00:00:00.000Z"), true);
+});
+
+test("log rotation resets a stale byte offset", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "proxy-watchdog-"));
+  const logFile = path.join(directory, "proxy.log");
+  const stateFile = path.join(directory, "state.json");
+  fs.writeFileSync(logFile, `${JSON.stringify({
+    routeUsage: true,
+    route: "/v1/a",
+    statusCode: 502,
+    errorCode: "upstream_error"
+  })}\n`);
+  fs.writeFileSync(stateFile, JSON.stringify({ logOffset: 99999 }));
+
+  const result = run({
+    logFile,
+    stateFile,
+    windowId: 10,
+    now: new Date("2026-08-21T10:00:00.000Z")
+  });
+
+  assert.equal(result.entries.length, 1);
+});


### PR DESCRIPTION
## Summary
- add an hourly proxy log watchdog with byte-offset state
- aggregate `route × statusCode × errorCode`, threshold 5xx/400, and require two consecutive windows
- dedupe by fingerprint, create/comment through `gh` only with explicit `--apply`, and cap comments to once per UTC day
- keep default operation dry-run and document gpu01 cron rollout

## TDD
- unit coverage for parsing, aggregation, thresholds, consecutive windows, issue body, comment cap, and log rotation
- log-rotation regression was observed failing before the offset reset fix

## Verification
- `node --test scripts/proxy-error-watchdog.test.mjs` (6/6 pass)
- Node and shell syntax checks pass
- two-window dry-run E2E produced an actionable 503 fingerprint only on the second window
- parsed the latest 5,000 gpu01 proxy log lines: 1,046 structured error routeUsage events, no current threshold breach
- root lint and typecheck pass
- root `npm run ci` reaches tests; unrelated local ignored `tools/k-skill-qa-bot` directory triggers the existing retired-daemon assertion

## Operator confirmation required
- [ ] Create the `auto-proxy-watchdog` label.
- [ ] Provision `gh` issues:write authentication on gpu01.
- [ ] Install the documented hourly dry-run cron for one week and tune thresholds.
- [ ] Add `--apply` only after reviewing dry-run output.

This PR remains draft until the operational rollout checks are complete.

Closes #607