### PR TITLE
fix(seoul-weather-risk): clip query windows to ASK Seoul availability

### DIFF
--- a/docs/features/seoul-weather-risk.md
+++ b/docs/features/seoul-weather-risk.md
@@ -78,6 +78,8 @@ npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.p
 
 `--fast`에서는 `--filter` 대신 `--admin-dong`, `--gu`, 날짜, `--limit`, `--cursor`를 사용합니다. `product_not_ready` 또는 계약 오류가 나오면 fixture로 대체하지 말고 게시 계약 진단을 수행합니다.
 
+`--from`과 `--to`에 날짜만 넣으면 그날 시작·끝 시각으로 확장됩니다. ASK 서울이 그 구간을 현재 serving window 밖이라고 거절하면 helper가 요청 구간과 제공 가능 window의 교집합으로 한 번 재시도합니다. 오늘 0시부터 조회해도 오후 예보 window만 열려 있으면 그 교집합만 조회하며, 없는 시간대를 임의로 채우지 않습니다.
+
 ## 게시 계약 진단
 
 아래 단계는 일반 질문마다 실행하지 않고, fast path 오류나 게시 상태 점검이 필요할 때만 실행합니다.
@@ -129,7 +131,7 @@ npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.p
 
 `--filter`가 필요하면 `--fast`를 빼고 이 full-contract 경로를 사용합니다. data 응답의 `publication_id`, `row_count`, `rows`, `has_more`, `next_cursor`를 확인하고 다음 page에는 같은 publication의 cursor만 재사용합니다.
 
-`--from`과 `--to`에 날짜만 넣으면 KST 기준으로 각각 `00:00:00`, `23:59:59`로 확장됩니다. 특정 시각이 필요하면 `2026-08-11 09:00:00`처럼 명시하세요.
+`--from`과 `--to`에 날짜만 넣으면 KST 기준으로 각각 `00:00:00`, `23:59:59`로 확장됩니다. 특정 시각이 필요하면 `2026-08-11 09:00:00`처럼 명시하세요. 확장한 하루가 현재 제공 window보다 앞이면 helper가 겹치는 구간으로 다시 조회합니다.
 
 ## 행정동 입력 규칙
 
@@ -192,6 +194,7 @@ npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.p
 | `product_not_ready` (503) | 제품이 아직 게시 준비되지 않음 | `catalog`의 `registration_ready`와 `blockers` 확인 |
 | `rate_limited` (429) | 호출 한도 초과 | 응답의 `Retry-After`를 따르고 재시도 |
 | `cursor_expired` (409) | publication이 바뀌어 cursor가 만료됨 | 첫 페이지부터 새로 조회 |
+| `query_window_unavailable` (422) | 요청 기간이 현재 제공 가능한 예보 window와 겹치지 않음 | 응답의 `available_from_at`/`available_to_at` 범위로 다시 조회. 겹치면 helper가 이미 재시도함 |
 | `response_contract_invalid` | API 응답 계약 또는 단일 제품 계약이 바뀜 | 성공 데이터로 처리하지 말고 운영자에게 신고 |
 | `network_error` | proxy 연결 실패 | 네트워크와 `KSKILL_PROXY_BASE_URL` 설정 확인 |
 

--- a/packages/k-skill-cli/skills/seoul-weather-risk/instruction.md
+++ b/packages/k-skill-cli/skills/seoul-weather-risk/instruction.md
@@ -51,6 +51,8 @@ npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.p
 
 `--filter`가 필요하거나 게시 계약을 점검해야 할 때는 `--fast`를 빼고 full-contract query를 사용한다. fast query가 `product_not_ready` 또는 계약 오류를 반환하면 fixture나 추정값으로 대체하지 말고 아래 진단 흐름을 수행한다.
 
+`--from`/`--to`에 날짜만 넣으면 그날 `00:00:00`–`23:59:59`로 확장한다. ASK 서울 serving window가 자정부터 열려 있지 않아 `422 query_window_unavailable`이 오면 helper는 요청 구간과 `available_from_at`/`available_to_at`의 교집합으로 한 번만 재시도한다. 교집합이 없으면 그 에러의 available window를 보여주고 중단한다. 없는 시간대를 추정 데이터로 채우지 않는다.
+
 ### Contract diagnostics (only when needed)
 
 1. 환경 설정만 확인한다. 이 명령은 네트워크를 호출하지 않는다.
@@ -99,6 +101,7 @@ npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.p
 - `location_mapping_invalid`: bundled 행정동 reference의 버전·스키마·행 수 계약 오류
 - `proxy_disabled`, `invalid_proxy_base_url`: proxy 환경 설정 오류
 - `unauthorized`/`api_key_missing`(401), `forbidden`/`api_key_forbidden`(403), `unknown_product`(404)
-- `cursor_expired`(409), `rate_limited`(429), `product_not_ready`(503)
+- `cursor_expired`(409), `query_window_unavailable`(422), `rate_limited`(429), `product_not_ready`(503)
+- `query_window_unavailable`: 요청한 `--from`/`--to`가 현재 제공 가능한 예보 window와 겹치지 않음. `details.available_from_at`/`available_to_at`를 확인한다. 겹치는 구간이면 helper가 이미 한 번 재시도한 뒤의 결과다.
 - `upstream_not_configured`(503): proxy 운영 환경에 ASK Seoul 전용 서비스 키 또는 origin이 설정되지 않음
 - `response_contract_invalid`, `malformed_response`: 단일 제품 계약 또는 API 응답 계약 drift

--- a/packages/k-skill-cli/skills/seoul-weather-risk/scripts/seoul_weather_risk.py
+++ b/packages/k-skill-cli/skills/seoul-weather-risk/scripts/seoul_weather_risk.py
@@ -33,9 +33,18 @@ STATUS_CODES = {
     403: "forbidden",
     404: "unknown_product",
     409: "cursor_expired",
+    422: "query_window_unavailable",
     429: "rate_limited",
     503: "product_not_ready",
 }
+WINDOW_INSTANT_LENGTH = len("YYYY-MM-DD HH:MM:SS")
+QUERY_WINDOW_DETAIL_FIELDS = (
+    "requested_from_at",
+    "requested_to_at",
+    "available_from_at",
+    "available_to_at",
+    "publication_id",
+)
 
 
 class SkillError(RuntimeError):
@@ -89,13 +98,20 @@ def _error_payload(raw: bytes) -> dict[str, Any]:
 def _problem_error(status: int, raw: bytes, headers: Any) -> SkillError:
     problem = _error_payload(raw)
     code = problem.get("code") if isinstance(problem.get("code"), str) else STATUS_CODES.get(status, "api_error")
-    message = problem.get("detail") if isinstance(problem.get("detail"), str) else problem.get("title")
+    raw_detail = problem.get("detail")
+    message = raw_detail if isinstance(raw_detail, str) else problem.get("title")
     if not isinstance(message, str) or not message:
         message = f"ASK Seoul API가 HTTP {status} 응답을 반환했습니다."
-    details = {"status": status}
+    details: dict[str, Any] = {"status": status}
     for name in ("type", "title", "product_id", "blockers", "request_id"):
         if name in problem:
             details[name] = problem[name]
+    if isinstance(raw_detail, dict):
+        details["detail"] = raw_detail
+        for name in QUERY_WINDOW_DETAIL_FIELDS:
+            value = raw_detail.get(name)
+            if isinstance(value, str) and value:
+                details[name] = value
     retry_after = headers.get("Retry-After") if headers else None
     if retry_after:
         details["retry_after"] = retry_after
@@ -238,6 +254,72 @@ def _time_bound(value: str, edge: str) -> str:
     return value
 
 
+def _window_sort_key(value: str) -> str | None:
+    text = " ".join(value.strip().replace("T", " ", 1).split())
+    if len(text) < WINDOW_INSTANT_LENGTH:
+        return None
+    key = text[:WINDOW_INSTANT_LENGTH]
+    if (
+        key[4] == "-"
+        and key[7] == "-"
+        and key[10] == " "
+        and key[13] == ":"
+        and key[16] == ":"
+        and key[:4].isdigit()
+        and key[5:7].isdigit()
+        and key[8:10].isdigit()
+        and key[11:13].isdigit()
+        and key[14:16].isdigit()
+        and key[17:19].isdigit()
+    ):
+        return key
+    return None
+
+
+def _intersect_query_window(
+    requested_from: str,
+    requested_to: str,
+    available_from: str,
+    available_to: str,
+) -> tuple[str, str] | None:
+    req_from = _window_sort_key(requested_from)
+    req_to = _window_sort_key(requested_to)
+    avail_from = _window_sort_key(available_from)
+    avail_to = _window_sort_key(available_to)
+    if req_from is None or req_to is None or avail_from is None or avail_to is None:
+        return None
+    clipped_from = max(req_from, avail_from)
+    clipped_to = min(req_to, avail_to)
+    if clipped_from > clipped_to:
+        return None
+    return clipped_from, clipped_to
+
+
+def _query_window_bounds(query: dict[str, str], error: SkillError) -> tuple[str, str, str, str] | None:
+    if error.details.get("status") != 422:
+        return None
+    available_from = error.details.get("available_from_at")
+    available_to = error.details.get("available_to_at")
+    requested_from = error.details.get("requested_from_at") or query.get("from")
+    requested_to = error.details.get("requested_to_at") or query.get("to")
+    if not all(isinstance(value, str) and value for value in (requested_from, requested_to, available_from, available_to)):
+        return None
+    return requested_from, requested_to, available_from, available_to
+
+
+def _retry_query_after_unavailable_window(query: dict[str, str], error: SkillError) -> dict[str, str] | None:
+    bounds = _query_window_bounds(query, error)
+    if bounds is None or query.get("cursor"):
+        return None
+    clipped = _intersect_query_window(*bounds)
+    if clipped is None:
+        return None
+    clipped_from, clipped_to = clipped
+    if query.get("from") == clipped_from and query.get("to") == clipped_to:
+        return None
+    return {**query, "from": clipped_from, "to": clipped_to}
+
+
 def _normalize_location_name(value: str) -> str:
     return " ".join(unicodedata.normalize("NFC", value).strip().split())
 
@@ -358,7 +440,21 @@ def _detail(config: ApiConfig, product_id: str) -> dict[str, Any]:
 
 def _data(config: ApiConfig, product_id: str, query: dict[str, str], limit: int) -> dict[str, Any]:
     _validate_product_id(product_id)
-    return _validate_data(_request_json(config, f"{PROXY_ROUTE_ROOT}/data", query), product_id, limit)
+    try:
+        payload = _request_json(config, f"{PROXY_ROUTE_ROOT}/data", query)
+    except SkillError as exc:
+        retry_query = _retry_query_after_unavailable_window(query, exc)
+        if retry_query is None:
+            bounds = _query_window_bounds(query, exc)
+            if bounds is not None and _intersect_query_window(*bounds) is None:
+                raise SkillError(
+                    "query_window_unavailable",
+                    "요청한 조회 구간이 현재 제공 가능한 예보 window와 겹치지 않습니다.",
+                    exc.details,
+                ) from exc
+            raise
+        payload = _request_json(config, f"{PROXY_ROUTE_ROOT}/data", retry_query)
+    return _validate_data(payload, product_id, limit)
 
 
 def _parser() -> argparse.ArgumentParser:

--- a/packages/k-skill-cli/test/snapshots/seoul-weather-risk.dolshoi.md
+++ b/packages/k-skill-cli/test/snapshots/seoul-weather-risk.dolshoi.md
@@ -70,6 +70,8 @@ npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.p
 
 `--filter`가 필요하거나 게시 계약을 점검해야 할 때는 `--fast`를 빼고 full-contract query를 사용한다. fast query가 `product_not_ready` 또는 계약 오류를 반환하면 fixture나 추정값으로 대체하지 말고 아래 진단 흐름을 수행한다.
 
+`--from`/`--to`에 날짜만 넣으면 그날 `00:00:00`–`23:59:59`로 확장한다. ASK 서울 serving window가 자정부터 열려 있지 않아 `422 query_window_unavailable`이 오면 helper는 요청 구간과 `available_from_at`/`available_to_at`의 교집합으로 한 번만 재시도한다. 교집합이 없으면 그 에러의 available window를 보여주고 중단한다. 없는 시간대를 추정 데이터로 채우지 않는다.
+
 ### Contract diagnostics (only when needed)
 
 1. 환경 설정만 확인한다. 이 명령은 네트워크를 호출하지 않는다.
@@ -118,6 +120,7 @@ npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.p
 - `location_mapping_invalid`: bundled 행정동 reference의 버전·스키마·행 수 계약 오류
 - `proxy_disabled`, `invalid_proxy_base_url`: proxy 환경 설정 오류
 - `unauthorized`/`api_key_missing`(401), `forbidden`/`api_key_forbidden`(403), `unknown_product`(404)
-- `cursor_expired`(409), `rate_limited`(429), `product_not_ready`(503)
+- `cursor_expired`(409), `query_window_unavailable`(422), `rate_limited`(429), `product_not_ready`(503)
+- `query_window_unavailable`: 요청한 `--from`/`--to`가 현재 제공 가능한 예보 window와 겹치지 않음. `details.available_from_at`/`available_to_at`를 확인한다. 겹치는 구간이면 helper가 이미 한 번 재시도한 뒤의 결과다.
 - `upstream_not_configured`(503): proxy 운영 환경에 ASK Seoul 전용 서비스 키 또는 origin이 설정되지 않음
 - `response_contract_invalid`, `malformed_response`: 단일 제품 계약 또는 API 응답 계약 drift

--- a/packages/k-skill-cli/test/snapshots/seoul-weather-risk.generic.md
+++ b/packages/k-skill-cli/test/snapshots/seoul-weather-risk.generic.md
@@ -70,6 +70,8 @@ npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.p
 
 `--filter`가 필요하거나 게시 계약을 점검해야 할 때는 `--fast`를 빼고 full-contract query를 사용한다. fast query가 `product_not_ready` 또는 계약 오류를 반환하면 fixture나 추정값으로 대체하지 말고 아래 진단 흐름을 수행한다.
 
+`--from`/`--to`에 날짜만 넣으면 그날 `00:00:00`–`23:59:59`로 확장한다. ASK 서울 serving window가 자정부터 열려 있지 않아 `422 query_window_unavailable`이 오면 helper는 요청 구간과 `available_from_at`/`available_to_at`의 교집합으로 한 번만 재시도한다. 교집합이 없으면 그 에러의 available window를 보여주고 중단한다. 없는 시간대를 추정 데이터로 채우지 않는다.
+
 ### Contract diagnostics (only when needed)
 
 1. 환경 설정만 확인한다. 이 명령은 네트워크를 호출하지 않는다.
@@ -118,6 +120,7 @@ npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.p
 - `location_mapping_invalid`: bundled 행정동 reference의 버전·스키마·행 수 계약 오류
 - `proxy_disabled`, `invalid_proxy_base_url`: proxy 환경 설정 오류
 - `unauthorized`/`api_key_missing`(401), `forbidden`/`api_key_forbidden`(403), `unknown_product`(404)
-- `cursor_expired`(409), `rate_limited`(429), `product_not_ready`(503)
+- `cursor_expired`(409), `query_window_unavailable`(422), `rate_limited`(429), `product_not_ready`(503)
+- `query_window_unavailable`: 요청한 `--from`/`--to`가 현재 제공 가능한 예보 window와 겹치지 않음. `details.available_from_at`/`available_to_at`를 확인한다. 겹치는 구간이면 helper가 이미 한 번 재시도한 뒤의 결과다.
 - `upstream_not_configured`(503): proxy 운영 환경에 ASK Seoul 전용 서비스 키 또는 origin이 설정되지 않음
 - `response_contract_invalid`, `malformed_response`: 단일 제품 계약 또는 API 응답 계약 drift

--- a/seoul-weather-risk/instruction.md
+++ b/seoul-weather-risk/instruction.md
@@ -51,6 +51,8 @@ npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.p
 
 `--filter`가 필요하거나 게시 계약을 점검해야 할 때는 `--fast`를 빼고 full-contract query를 사용한다. fast query가 `product_not_ready` 또는 계약 오류를 반환하면 fixture나 추정값으로 대체하지 말고 아래 진단 흐름을 수행한다.
 
+`--from`/`--to`에 날짜만 넣으면 그날 `00:00:00`–`23:59:59`로 확장한다. ASK 서울 serving window가 자정부터 열려 있지 않아 `422 query_window_unavailable`이 오면 helper는 요청 구간과 `available_from_at`/`available_to_at`의 교집합으로 한 번만 재시도한다. 교집합이 없으면 그 에러의 available window를 보여주고 중단한다. 없는 시간대를 추정 데이터로 채우지 않는다.
+
 ### Contract diagnostics (only when needed)
 
 1. 환경 설정만 확인한다. 이 명령은 네트워크를 호출하지 않는다.
@@ -99,6 +101,7 @@ npx -y @nomadamas/k-skill@0 exec seoul-weather-risk scripts/seoul_weather_risk.p
 - `location_mapping_invalid`: bundled 행정동 reference의 버전·스키마·행 수 계약 오류
 - `proxy_disabled`, `invalid_proxy_base_url`: proxy 환경 설정 오류
 - `unauthorized`/`api_key_missing`(401), `forbidden`/`api_key_forbidden`(403), `unknown_product`(404)
-- `cursor_expired`(409), `rate_limited`(429), `product_not_ready`(503)
+- `cursor_expired`(409), `query_window_unavailable`(422), `rate_limited`(429), `product_not_ready`(503)
+- `query_window_unavailable`: 요청한 `--from`/`--to`가 현재 제공 가능한 예보 window와 겹치지 않음. `details.available_from_at`/`available_to_at`를 확인한다. 겹치는 구간이면 helper가 이미 한 번 재시도한 뒤의 결과다.
 - `upstream_not_configured`(503): proxy 운영 환경에 ASK Seoul 전용 서비스 키 또는 origin이 설정되지 않음
 - `response_contract_invalid`, `malformed_response`: 단일 제품 계약 또는 API 응답 계약 drift

--- a/seoul-weather-risk/scripts/seoul_weather_risk.py
+++ b/seoul-weather-risk/scripts/seoul_weather_risk.py
@@ -33,9 +33,18 @@ STATUS_CODES = {
     403: "forbidden",
     404: "unknown_product",
     409: "cursor_expired",
+    422: "query_window_unavailable",
     429: "rate_limited",
     503: "product_not_ready",
 }
+WINDOW_INSTANT_LENGTH = len("YYYY-MM-DD HH:MM:SS")
+QUERY_WINDOW_DETAIL_FIELDS = (
+    "requested_from_at",
+    "requested_to_at",
+    "available_from_at",
+    "available_to_at",
+    "publication_id",
+)
 
 
 class SkillError(RuntimeError):
@@ -89,13 +98,20 @@ def _error_payload(raw: bytes) -> dict[str, Any]:
 def _problem_error(status: int, raw: bytes, headers: Any) -> SkillError:
     problem = _error_payload(raw)
     code = problem.get("code") if isinstance(problem.get("code"), str) else STATUS_CODES.get(status, "api_error")
-    message = problem.get("detail") if isinstance(problem.get("detail"), str) else problem.get("title")
+    raw_detail = problem.get("detail")
+    message = raw_detail if isinstance(raw_detail, str) else problem.get("title")
     if not isinstance(message, str) or not message:
         message = f"ASK Seoul API가 HTTP {status} 응답을 반환했습니다."
-    details = {"status": status}
+    details: dict[str, Any] = {"status": status}
     for name in ("type", "title", "product_id", "blockers", "request_id"):
         if name in problem:
             details[name] = problem[name]
+    if isinstance(raw_detail, dict):
+        details["detail"] = raw_detail
+        for name in QUERY_WINDOW_DETAIL_FIELDS:
+            value = raw_detail.get(name)
+            if isinstance(value, str) and value:
+                details[name] = value
     retry_after = headers.get("Retry-After") if headers else None
     if retry_after:
         details["retry_after"] = retry_after
@@ -238,6 +254,72 @@ def _time_bound(value: str, edge: str) -> str:
     return value
 
 
+def _window_sort_key(value: str) -> str | None:
+    text = " ".join(value.strip().replace("T", " ", 1).split())
+    if len(text) < WINDOW_INSTANT_LENGTH:
+        return None
+    key = text[:WINDOW_INSTANT_LENGTH]
+    if (
+        key[4] == "-"
+        and key[7] == "-"
+        and key[10] == " "
+        and key[13] == ":"
+        and key[16] == ":"
+        and key[:4].isdigit()
+        and key[5:7].isdigit()
+        and key[8:10].isdigit()
+        and key[11:13].isdigit()
+        and key[14:16].isdigit()
+        and key[17:19].isdigit()
+    ):
+        return key
+    return None
+
+
+def _intersect_query_window(
+    requested_from: str,
+    requested_to: str,
+    available_from: str,
+    available_to: str,
+) -> tuple[str, str] | None:
+    req_from = _window_sort_key(requested_from)
+    req_to = _window_sort_key(requested_to)
+    avail_from = _window_sort_key(available_from)
+    avail_to = _window_sort_key(available_to)
+    if req_from is None or req_to is None or avail_from is None or avail_to is None:
+        return None
+    clipped_from = max(req_from, avail_from)
+    clipped_to = min(req_to, avail_to)
+    if clipped_from > clipped_to:
+        return None
+    return clipped_from, clipped_to
+
+
+def _query_window_bounds(query: dict[str, str], error: SkillError) -> tuple[str, str, str, str] | None:
+    if error.details.get("status") != 422:
+        return None
+    available_from = error.details.get("available_from_at")
+    available_to = error.details.get("available_to_at")
+    requested_from = error.details.get("requested_from_at") or query.get("from")
+    requested_to = error.details.get("requested_to_at") or query.get("to")
+    if not all(isinstance(value, str) and value for value in (requested_from, requested_to, available_from, available_to)):
+        return None
+    return requested_from, requested_to, available_from, available_to
+
+
+def _retry_query_after_unavailable_window(query: dict[str, str], error: SkillError) -> dict[str, str] | None:
+    bounds = _query_window_bounds(query, error)
+    if bounds is None or query.get("cursor"):
+        return None
+    clipped = _intersect_query_window(*bounds)
+    if clipped is None:
+        return None
+    clipped_from, clipped_to = clipped
+    if query.get("from") == clipped_from and query.get("to") == clipped_to:
+        return None
+    return {**query, "from": clipped_from, "to": clipped_to}
+
+
 def _normalize_location_name(value: str) -> str:
     return " ".join(unicodedata.normalize("NFC", value).strip().split())
 
@@ -358,7 +440,21 @@ def _detail(config: ApiConfig, product_id: str) -> dict[str, Any]:
 
 def _data(config: ApiConfig, product_id: str, query: dict[str, str], limit: int) -> dict[str, Any]:
     _validate_product_id(product_id)
-    return _validate_data(_request_json(config, f"{PROXY_ROUTE_ROOT}/data", query), product_id, limit)
+    try:
+        payload = _request_json(config, f"{PROXY_ROUTE_ROOT}/data", query)
+    except SkillError as exc:
+        retry_query = _retry_query_after_unavailable_window(query, exc)
+        if retry_query is None:
+            bounds = _query_window_bounds(query, exc)
+            if bounds is not None and _intersect_query_window(*bounds) is None:
+                raise SkillError(
+                    "query_window_unavailable",
+                    "요청한 조회 구간이 현재 제공 가능한 예보 window와 겹치지 않습니다.",
+                    exc.details,
+                ) from exc
+            raise
+        payload = _request_json(config, f"{PROXY_ROUTE_ROOT}/data", retry_query)
+    return _validate_data(payload, product_id, limit)
 
 
 def _parser() -> argparse.ArgumentParser:

--- a/seoul-weather-risk/tests/test_seoul_weather_risk.py
+++ b/seoul-weather-risk/tests/test_seoul_weather_risk.py
@@ -82,8 +82,10 @@ class MockApi:
         class Handler(BaseHTTPRequestHandler):
             def do_GET(self):
                 parsed = urlparse(self.path)
-                api.requests.append({"path": parsed.path, "query": parse_qs(parsed.query), "authorization": self.headers.get("Authorization")})
-                status, content_type, body, headers = api.responses.get(parsed.path, (404, "application/problem+json", {"code": "unknown_product", "detail": "not found"}, {}))
+                query = parse_qs(parsed.query)
+                api.requests.append({"path": parsed.path, "query": query, "authorization": self.headers.get("Authorization")})
+                entry = api.responses.get(parsed.path, (404, "application/problem+json", {"code": "unknown_product", "detail": "not found"}, {}))
+                status, content_type, body, headers = entry(query) if callable(entry) else entry
                 encoded = body if isinstance(body, bytes) else json.dumps(body).encode("utf-8")
                 self.send_response(status)
                 self.send_header("Content-Type", content_type)
@@ -109,6 +111,39 @@ class MockApi:
         self.server.shutdown()
         self.server.server_close()
         self.thread.join()
+
+
+class QueryWindowClipTests(unittest.TestCase):
+    def test_window_sort_key_normalizes_iso_and_timezone_suffix(self):
+        self.assertEqual(
+            seoul_weather_risk._window_sort_key("2026-08-24T17:00:00+09:00"),
+            "2026-08-24 17:00:00",
+        )
+        self.assertEqual(
+            seoul_weather_risk._window_sort_key("2026-08-24 17:00:00"),
+            "2026-08-24 17:00:00",
+        )
+
+    def test_intersect_query_window_clips_to_overlap(self):
+        self.assertEqual(
+            seoul_weather_risk._intersect_query_window(
+                "2026-08-24 00:00:00",
+                "2026-08-24 23:59:59",
+                "2026-08-24 17:00:00",
+                "2026-08-27 00:00:00",
+            ),
+            ("2026-08-24 17:00:00", "2026-08-24 23:59:59"),
+        )
+
+    def test_intersect_query_window_returns_none_when_ranges_do_not_overlap(self):
+        self.assertIsNone(
+            seoul_weather_risk._intersect_query_window(
+                "2026-08-11 00:00:00",
+                "2026-08-17 23:59:59",
+                "2026-08-24 17:00:00",
+                "2026-08-27 00:00:00",
+            )
+        )
 
 
 class ApiClientTests(unittest.TestCase):
@@ -210,6 +245,128 @@ class ApiClientTests(unittest.TestCase):
             "limit": ["100"],
         })
 
+    def test_query_clips_calendar_day_to_available_window(self):
+        def data_response(query):
+            if query.get("from") == ["2026-08-24 00:00:00"] and query.get("to") == ["2026-08-24 23:59:59"]:
+                return (422, "application/problem+json", {
+                    "title": "query window unavailable",
+                    "status": 422,
+                    "detail": {
+                        "requested_from_at": "2026-08-24 00:00:00",
+                        "requested_to_at": "2026-08-24 23:59:59",
+                        "available_from_at": "2026-08-24 17:00:00",
+                        "available_to_at": "2026-08-27 00:00:00",
+                        "publication_id": "publication-1",
+                    },
+                }, {})
+            if query.get("from") == ["2026-08-24 17:00:00"] and query.get("to") == ["2026-08-24 23:59:59"]:
+                return (200, "application/json", data(), {})
+            return (500, "application/json", {"error": "unexpected query"}, {})
+
+        self.api.responses["/v1/ask-seoul/weather-risk/data"] = data_response
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            code = seoul_weather_risk.run([
+                "query", "--fast", "--product-id", PRODUCT_ID,
+                "--admin-dong", "잠실본동", "--from", "2026-08-24", "--to", "2026-08-24", "--limit", "100",
+            ])
+
+        self.assertEqual(code, 0)
+        self.assertEqual(json.loads(stdout.getvalue())["row_count"], 1)
+        self.assertEqual([request["path"] for request in self.api.requests], [
+            "/v1/ask-seoul/weather-risk/data",
+            "/v1/ask-seoul/weather-risk/data",
+        ])
+        self.assertEqual(self.api.requests[0]["query"]["from"], ["2026-08-24 00:00:00"])
+        self.assertEqual(self.api.requests[0]["query"]["to"], ["2026-08-24 23:59:59"])
+        self.assertEqual(self.api.requests[1]["query"], {
+            "place_id": ["seoul_admd_1171065000"],
+            "from": ["2026-08-24 17:00:00"],
+            "to": ["2026-08-24 23:59:59"],
+            "limit": ["100"],
+        })
+
+    def test_query_window_without_overlap_fails_with_available_bounds(self):
+        self.api.responses["/v1/ask-seoul/weather-risk/data"] = (
+            422,
+            "application/problem+json",
+            {
+                "title": "query window unavailable",
+                "status": 422,
+                "request_id": "req-window",
+                "detail": {
+                    "requested_from_at": "2026-08-11 00:00:00",
+                    "requested_to_at": "2026-08-17 23:59:59",
+                    "available_from_at": "2026-08-24 17:00:00",
+                    "available_to_at": "2026-08-27 00:00:00",
+                    "publication_id": "publication-1",
+                },
+            },
+            {},
+        )
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            code = seoul_weather_risk.run([
+                "query", "--fast", "--product-id", PRODUCT_ID,
+                "--admin-dong", "잠실본동", "--from", "2026-08-11", "--to", "2026-08-17",
+            ])
+
+        error = json.loads(stderr.getvalue())["error"]
+        self.assertEqual(code, 2)
+        self.assertEqual(error["code"], "query_window_unavailable")
+        self.assertIn("겹치지 않습니다", error["message"])
+        self.assertEqual(error["details"]["available_from_at"], "2026-08-24 17:00:00")
+        self.assertEqual(error["details"]["available_to_at"], "2026-08-27 00:00:00")
+        self.assertEqual(error["details"]["request_id"], "req-window")
+        self.assertEqual(len(self.api.requests), 1)
+
+    def test_query_window_problem_without_available_bounds_does_not_retry(self):
+        self.api.responses["/v1/ask-seoul/weather-risk/data"] = (
+            422,
+            "application/problem+json",
+            {"title": "query window unavailable", "detail": "safe problem detail", "code": "query_window_unavailable"},
+            {},
+        )
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            code = seoul_weather_risk.run([
+                "query", "--fast", "--product-id", PRODUCT_ID,
+                "--admin-dong", "잠실본동", "--from", "2026-08-24", "--to", "2026-08-24",
+            ])
+
+        error = json.loads(stderr.getvalue())["error"]
+        self.assertEqual(code, 2)
+        self.assertEqual(error["code"], "query_window_unavailable")
+        self.assertEqual(error["message"], "safe problem detail")
+        self.assertEqual(len(self.api.requests), 1)
+
+    def test_paged_query_does_not_retry_unavailable_window(self):
+        self.api.responses["/v1/ask-seoul/weather-risk/data"] = (
+            422,
+            "application/problem+json",
+            {
+                "title": "query window unavailable",
+                "status": 422,
+                "detail": {
+                    "requested_from_at": "2026-08-24 00:00:00",
+                    "requested_to_at": "2026-08-24 23:59:59",
+                    "available_from_at": "2026-08-24 17:00:00",
+                    "available_to_at": "2026-08-27 00:00:00",
+                },
+            },
+            {},
+        )
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            code = seoul_weather_risk.run([
+                "query", "--fast", "--product-id", PRODUCT_ID,
+                "--admin-dong", "잠실본동", "--from", "2026-08-24", "--to", "2026-08-24",
+                "--cursor", "cursor-1",
+            ])
+
+        self.assertEqual(code, 2)
+        self.assertEqual(json.loads(stderr.getvalue())["error"]["code"], "query_window_unavailable")
+        self.assertEqual(len(self.api.requests), 1)
 
     def test_query_maps_admin_dong_to_place_id_before_proxy_request(self):
         self.api.responses["/v1/ask-seoul/weather-risk/data"] = (


### PR DESCRIPTION
## Summary
- ASK 서울 data route는 `from`/`to`가 현재 serving window에 **완전히 포함**될 때만 받습니다. 날짜만 주면 helper가 `00:00:00`–`23:59:59`로 펼쳐서, 오후 이후 `available_from_at`보다 앞선 오늘 조회가 422로 죽었습니다.
- 422 `query_window_unavailable`이면 요청 구간과 `available_from_at`/`available_to_at`의 교집합으로 **한 번만** 재시도합니다. 교집합이 없으면 available window를 에러 detail에 남기고 중단합니다. cursor가 있는 페이지 요청은 재시도하지 않습니다.
- 없는 시간대를 fixture/추정값으로 채우지 않습니다.

## Test plan
- [x] `python3 -m unittest seoul-weather-risk.tests.test_seoul_weather_risk -v` (38 tests)
- [x] 로컬 helper → 프로덕션 proxy: `--from 2026-08-24 --to 2026-08-24` 가 422 대신 200, `query_context.requested_from_at=2026-08-24 17:00:00`
- [x] 지난주 구간은 교집합 없음 → `query_window_unavailable` + `available_from_at`/`available_to_at`