### PR TITLE
fix: the k-skill-proxy server defines multiple publi... in server.js

### DIFF
--- a/packages/k-skill-proxy/src/server.js
+++ b/packages/k-skill-proxy/src/server.js
@@ -2261,7 +2261,10 @@ function buildServer({ env = process.env, provider = null, now = () => new Date(
     return payload;
   });
 
-  app.get("/health", async () => {
+  app.get("/health", async (request, reply) => {
+    if (!rateLimit(request, reply)) {
+      return reply;
+    }
     const naverSearchKeysPresent = Boolean(config.naverSearchClientId && config.naverSearchClientSecret);
     return {
       ok: true,


### PR DESCRIPTION
## Summary
Fix high severity security issue in `packages/k-skill-proxy/src/server.js`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-003 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-003` |
| **File** | `packages/k-skill-proxy/src/server.js:2264` |
| **Assessment** | Likely exploitable |

**Description**: The k-skill-proxy server defines multiple public API endpoints without implementing rate limiting middleware. While a buildRateLimiter function exists, it is not consistently applied to all public endpoints, leaving them vulnerable to abuse.

## Evidence

**Exploitation scenario**: Send high-volume automated requests to public endpoints (/health, /v1/vworld/search, /v1/fine-dust/report, /v1/assembly/bills) to exhaust server resources (CPU, memory, database connections),.

**Scanner confirmation**: multi_agent_ai rule `V-003` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a private Node.js application (not published to npm). Vulnerabilities affect this application's own runtime only.

## Changes
- `packages/k-skill-proxy/src/server.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
