### PR TITLE
chore: add missing changeset for real-estate nationwide report

### DIFF
--- a/.changeset/fresh-realestate-report.md
+++ b/.changeset/fresh-realestate-report.md
@@ -1,0 +1,5 @@
+---
+"@nomadamas/k-skill": minor
+---
+
+Add the official RTMS nationwide daily report helper to the real-estate-search CLI bundle.


### PR DESCRIPTION
## 요약

PR #649가 `@nomadamas/k-skill` CLI 번들에 RTMS 전국 일보고 helper를 넣었지만 changeset이 없어서 Version Packages PR이 열리지 않았습니다. 누락된 changeset을 추가합니다.

## 변경 범위

- `.changeset/fresh-realestate-report.md` (`@nomadamas/k-skill`: minor)

## 검증

- changeset 파일만 추가. 런타임 코드 변경 없음.
- 이 PR을 `main`에 머지하면 `release-npm.yml`이 Version Packages PR을 생성합니다.