### PR TITLE
fix(proxy-ops): auto-recover gpu01 services after reboot (#658)

### DIFF
--- a/docs/deploy-k-skill-proxy.md
+++ b/docs/deploy-k-skill-proxy.md
@@ -8,7 +8,7 @@ domain is served by a Cloudflare Tunnel that forwards to the Fastify process on
 
 | Item | Value |
 | --- | --- |
-| Host | `gpu01` (`gpu01.nomadamas.org`) |
+| Host | `gpu01` (`gpu01.nomadamas.org`; `hostname -s` is `marker-multi-gpu-server-01`) |
 | Public URL | `https://k-skill-proxy.nomadamas.org` |
 | App directory | `/data/home/jeffrey/apps/k-skill-proxy` |
 | Source checkout | `/data/home/jeffrey/apps/k-skill-proxy-repo` |
@@ -18,7 +18,7 @@ domain is served by a Cloudflare Tunnel that forwards to the Fastify process on
 | Deployed revision | `/data/home/jeffrey/apps/k-skill-proxy/deployed-sha` |
 | Deploy script | `scripts/deploy-k-skill-proxy-gpu01.sh` |
 
-The production listener is bound to `127.0.0.1` and receives public traffic through exactly one local Cloudflare Tunnel hop. Only when the gpu01 deployment script is running with `KSKILL_PROXY_DEPLOY_ENVIRONMENT=production` and `KSKILL_PROXY_DEPLOY_HOST=gpu01` does it ensure the runtime env contains `KSKILL_PROXY_TRUST_PROXY_HOPS=1` before restarting the service. Those values are the script defaults on the production host. Non-production or non-gpu01 executions leave the application default at `0`. An explicit operator value is preserved, and `KSKILL_PROXY_ENV_FILE` may point the script at a non-default runtime env path.
+The production listener is bound to `127.0.0.1` and receives public traffic through exactly one local Cloudflare Tunnel hop. Only when the gpu01 deployment script is running with `KSKILL_PROXY_DEPLOY_ENVIRONMENT=production` and a production host (`KSKILL_PROXY_DEPLOY_HOST=gpu01`, or `hostname -s` of `gpu01` / `marker-multi-gpu-server-01`) does it ensure the runtime env contains `KSKILL_PROXY_TRUST_PROXY_HOPS=1` before restarting the service. Cron should set `KSKILL_PROXY_DEPLOY_HOST=gpu01` explicitly. Non-production or non-gpu01 executions leave the application default at `0`. An explicit operator value is preserved, and `KSKILL_PROXY_ENV_FILE` may point the script at a non-default runtime env path.
 
 Do not use this setting for a directly exposed listener. Trusting one hop is safe here because the Fastify port is loopback-only; making that port externally reachable would allow clients to supply a forged `X-Forwarded-For` value.
 
@@ -68,6 +68,7 @@ unit files live in the repo:
 
 | Unit | Repo source |
 | --- | --- |
+| proxy | `infra/k-skill-proxy-dashboard/systemd/k-skill-proxy.service` |
 | tunnel | `infra/k-skill-proxy-dashboard/systemd/k-skill-proxy-tunnel.service` |
 | loki / promtail / grafana | `infra/k-skill-proxy-dashboard/systemd/` |
 
@@ -78,7 +79,14 @@ NFS mount and must not be exec'd before the mount is up at boot.
 Install or repair the cron entry:
 
 ```cron
-*/5 * * * * flock -n /tmp/k-skill-proxy-deploy.lock /data/home/jeffrey/apps/k-skill-proxy/deploy-k-skill-proxy-gpu01.sh >> /data/home/jeffrey/apps/k-skill-proxy/deploy.log 2>&1
+*/5 * * * * KSKILL_PROXY_DEPLOY_HOST=gpu01 flock -n /tmp/k-skill-proxy-deploy.lock /data/home/jeffrey/apps/k-skill-proxy/deploy-k-skill-proxy-gpu01.sh >> /data/home/jeffrey/apps/k-skill-proxy/deploy.log 2>&1
+```
+
+The SSH alias is `gpu01`, but `hostname -s` on the box is `marker-multi-gpu-server-01`. The deploy script treats both as production; still set `KSKILL_PROXY_DEPLOY_HOST=gpu01` in cron so a hostname change cannot silently disable the watchdog. After the first `main` deploy that includes this script, it copies itself onto `$APP_DIR/deploy-k-skill-proxy-gpu01.sh`. Until then, install it once:
+
+```bash
+install -m 0755 /data/home/jeffrey/apps/k-skill-proxy-repo/scripts/deploy-k-skill-proxy-gpu01.sh \
+  /data/home/jeffrey/apps/k-skill-proxy/deploy-k-skill-proxy-gpu01.sh
 ```
 
 ## Manual operation

--- a/docs/deploy-k-skill-proxy.md
+++ b/docs/deploy-k-skill-proxy.md
@@ -40,6 +40,41 @@ Any failure after the backup performs an automatic rollback by restoring the
 previous files and restarting the old service. A `main` merge is therefore deployed within the cron interval when the
 new proxy tests and smoke checks pass.
 
+### Service watchdog
+
+Every cron run — including runs that exit early because `deployed-sha` already
+matches — first ensures the production services are active before anything
+else. If any of them is installed but not active, the script starts it. This
+exists because the 2026-08-29 gpu01 reboot left the Cloudflare tunnel and the
+Loki/Grafana/Promtail dashboard stack dead for ~10 days: their units used
+`Restart=on-failure`, which does not revive a clean SIGTERM, and nothing else
+ever started them. The proxy only survived because this same cron happens to
+`restart` it on every run.
+
+Watched services (production gpu01 only, overridable via
+`KSKILL_PROXY_WATCHED_SERVICES`):
+
+| Service | Role |
+| --- | --- |
+| `k-skill-proxy.service` | Fastify proxy |
+| `k-skill-proxy-tunnel.service` | cloudflared tunnel for both public hostnames |
+| `k-skill-proxy-loki.service` | log store |
+| `k-skill-proxy-promtail.service` | log shipper |
+| `k-skill-proxy-grafana.service` | dashboard UI |
+
+All five units use `Restart=always` with `StartLimitIntervalSec=0` so a clean
+stop or repeated failure never disables restart permanently. The canonical
+unit files live in the repo:
+
+| Unit | Repo source |
+| --- | --- |
+| tunnel | `infra/k-skill-proxy-dashboard/systemd/k-skill-proxy-tunnel.service` |
+| loki / promtail / grafana | `infra/k-skill-proxy-dashboard/systemd/` |
+
+The tunnel unit also carries `RequiresMountsFor=` on the cloudflared binary,
+its config, and the app directory, because all three live on the `gpu02:/data`
+NFS mount and must not be exec'd before the mount is up at boot.
+
 Install or repair the cron entry:
 
 ```cron

--- a/infra/k-skill-proxy-dashboard/README.md
+++ b/infra/k-skill-proxy-dashboard/README.md
@@ -28,15 +28,15 @@ The script:
    never overwritten and must never be committed to git;
 3. rewrites provisioning paths into `data/provisioning`;
 4. installs and starts `k-skill-proxy-{loki,promtail,grafana}.service`
-   (Grafana on `127.0.0.1:3200`).
+   (Grafana on `127.0.0.1:3200`) and installs/enables the tunnel unit without
+   restarting it.
 
 The canonical systemd unit files live in `systemd/`. All units use
 `Restart=always` with `StartLimitIntervalSec=0` so a reboot or a clean stop
 cannot leave the stack dead until manual intervention. The Cloudflare tunnel
-unit (`systemd/k-skill-proxy-tunnel.service`, which also serves the proxy
-hostname) lives here too; it additionally pins `RequiresMountsFor=` on the
-NFS-backed cloudflared binary/config/app paths so it waits for `gpu02:/data`
-at boot instead of crash-looping past the start limit.
+and Fastify proxy units live here too; they additionally pin `RequiresMountsFor=`
+on the NFS-backed paths so they wait for `gpu02:/data` at boot instead of
+crash-looping past the start limit.
 
 Public access goes through the existing cloudflared tunnel
 (`~/.cloudflared/config.yml`, hostname

--- a/infra/k-skill-proxy-dashboard/README.md
+++ b/infra/k-skill-proxy-dashboard/README.md
@@ -30,6 +30,14 @@ The script:
 4. installs and starts `k-skill-proxy-{loki,promtail,grafana}.service`
    (Grafana on `127.0.0.1:3200`).
 
+The canonical systemd unit files live in `systemd/`. All units use
+`Restart=always` with `StartLimitIntervalSec=0` so a reboot or a clean stop
+cannot leave the stack dead until manual intervention. The Cloudflare tunnel
+unit (`systemd/k-skill-proxy-tunnel.service`, which also serves the proxy
+hostname) lives here too; it additionally pins `RequiresMountsFor=` on the
+NFS-backed cloudflared binary/config/app paths so it waits for `gpu02:/data`
+at boot instead of crash-looping past the start limit.
+
 Public access goes through the existing cloudflared tunnel
 (`~/.cloudflared/config.yml`, hostname
 `k-skill-proxy-dashboard.nomadamas.org -> http://localhost:3200`, DNS route

--- a/infra/k-skill-proxy-dashboard/setup-gpu01.sh
+++ b/infra/k-skill-proxy-dashboard/setup-gpu01.sh
@@ -92,12 +92,16 @@ install_units() {
   install -m 0644 "$APP_DIR/systemd/k-skill-proxy-loki.service" \
     "$APP_DIR/systemd/k-skill-proxy-promtail.service" \
     "$APP_DIR/systemd/k-skill-proxy-grafana.service" \
+    "$APP_DIR/systemd/k-skill-proxy-tunnel.service" \
     "$HOME/.config/systemd/user/"
   systemctl --user daemon-reload
   systemctl --user enable --now k-skill-proxy-loki.service
   systemctl --user enable --now k-skill-proxy-promtail.service
   systemctl --user enable --now k-skill-proxy-grafana.service
   systemctl --user restart k-skill-proxy-loki.service k-skill-proxy-promtail.service k-skill-proxy-grafana.service
+  # Install/enable the tunnel unit but do not restart it here: this script is
+  # the dashboard installer, and bouncing cloudflared would drop public proxy.
+  systemctl --user enable k-skill-proxy-tunnel.service
 }
 
 install_grafana

--- a/infra/k-skill-proxy-dashboard/systemd/k-skill-proxy-grafana.service
+++ b/infra/k-skill-proxy-dashboard/systemd/k-skill-proxy-grafana.service
@@ -2,12 +2,13 @@
 Description=Grafana dashboard for k-skill-proxy usage stats
 After=network-online.target k-skill-proxy-loki.service
 Wants=network-online.target
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple
 EnvironmentFile=%h/apps/k-skill-proxy-dashboard/grafana.env
 ExecStart=%h/apps/k-skill-proxy-dashboard/bin/grafana/bin/grafana server --homepath %h/apps/k-skill-proxy-dashboard/bin/grafana
-Restart=on-failure
+Restart=always
 RestartSec=3
 
 [Install]

--- a/infra/k-skill-proxy-dashboard/systemd/k-skill-proxy-loki.service
+++ b/infra/k-skill-proxy-dashboard/systemd/k-skill-proxy-loki.service
@@ -2,11 +2,12 @@
 Description=Loki log store for k-skill-proxy usage dashboard
 After=network-online.target
 Wants=network-online.target
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple
 ExecStart=%h/apps/k-skill-proxy-dashboard/bin/loki -config.file=%h/apps/k-skill-proxy-dashboard/gpu01/loki.yml
-Restart=on-failure
+Restart=always
 RestartSec=3
 
 [Install]

--- a/infra/k-skill-proxy-dashboard/systemd/k-skill-proxy-promtail.service
+++ b/infra/k-skill-proxy-dashboard/systemd/k-skill-proxy-promtail.service
@@ -2,11 +2,12 @@
 Description=Promtail shipper for k-skill-proxy logs
 After=network-online.target k-skill-proxy-loki.service
 Wants=network-online.target
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple
 ExecStart=%h/apps/k-skill-proxy-dashboard/bin/promtail -config.file=%h/apps/k-skill-proxy-dashboard/gpu01/promtail.yml
-Restart=on-failure
+Restart=always
 RestartSec=3
 
 [Install]

--- a/infra/k-skill-proxy-dashboard/systemd/k-skill-proxy-tunnel.service
+++ b/infra/k-skill-proxy-dashboard/systemd/k-skill-proxy-tunnel.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=cloudflared tunnel for k-skill-proxy.nomadamas.org
+After=network-online.target k-skill-proxy.service
+Wants=network-online.target
+# cloudflared, its config, and the app directory live on the gpu02:/data NFS
+# mount, so wait for it before attempting ExecStart at boot.
+RequiresMountsFor=/data/home/jeffrey/bin/cloudflared /data/home/jeffrey/.cloudflared /data/home/jeffrey/apps/k-skill-proxy
+# Never give up restarting: a clean stop or NFS unavailability must not leave
+# the public endpoint dark until the next manual intervention.
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+ExecStart=/data/home/jeffrey/bin/cloudflared --no-autoupdate --config /data/home/jeffrey/.cloudflared/config.yml tunnel run k-skill-proxy
+Restart=always
+RestartSec=5
+StandardOutput=append:/data/home/jeffrey/apps/k-skill-proxy/tunnel.log
+StandardError=append:/data/home/jeffrey/apps/k-skill-proxy/tunnel.log
+
+[Install]
+WantedBy=default.target

--- a/infra/k-skill-proxy-dashboard/systemd/k-skill-proxy.service
+++ b/infra/k-skill-proxy-dashboard/systemd/k-skill-proxy.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=k-skill-proxy (Fastify upstream API proxy)
+After=network-online.target
+Wants=network-online.target
+# App dir lives on the gpu02:/data NFS mount.
+RequiresMountsFor=/data/home/jeffrey/apps/k-skill-proxy
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+WorkingDirectory=/data/home/jeffrey/apps/k-skill-proxy/packages/k-skill-proxy
+EnvironmentFile=/data/home/jeffrey/apps/k-skill-proxy/.env
+ExecStart=/usr/bin/node src/server.js
+Restart=always
+RestartSec=3
+StandardOutput=append:/data/home/jeffrey/apps/k-skill-proxy/proxy.log
+StandardError=append:/data/home/jeffrey/apps/k-skill-proxy/proxy.log
+
+[Install]
+WantedBy=default.target

--- a/scripts/deploy-k-skill-proxy-gpu01.sh
+++ b/scripts/deploy-k-skill-proxy-gpu01.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# cron has no user-session bus; systemctl --user needs these.
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+export DBUS_SESSION_BUS_ADDRESS="${DBUS_SESSION_BUS_ADDRESS:-unix:path=${XDG_RUNTIME_DIR}/bus}"
+
 REPO_URL="${KSKILL_PROXY_REPO_URL:-git@github.com:NomaDamas/k-skill.git}"
 REPO_DIR="${KSKILL_PROXY_REPO_DIR:-/data/home/jeffrey/apps/k-skill-proxy-repo}"
 APP_DIR="${KSKILL_PROXY_APP_DIR:-/data/home/jeffrey/apps/k-skill-proxy}"
@@ -47,12 +51,28 @@ ensure_env_default() {
   log "Added required runtime default: $key=$value"
 }
 
+is_gpu01_production() {
+  local deploy_environment="$1"
+  local deploy_host="$2"
+
+  if [[ "$deploy_environment" != "production" ]]; then
+    return 1
+  fi
+
+  # SSH alias is gpu01; hostname -s on the box is marker-multi-gpu-server-01.
+  # Crontab should also set KSKILL_PROXY_DEPLOY_HOST=gpu01.
+  case "$deploy_host" in
+    gpu01|marker-multi-gpu-server-01) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 ensure_gpu01_production_defaults() {
   local env_file="$1"
   local deploy_environment="$2"
   local deploy_host="$3"
 
-  if [[ "$deploy_environment" != "production" || "$deploy_host" != "gpu01" ]]; then
+  if ! is_gpu01_production "$deploy_environment" "$deploy_host"; then
     return
   fi
 
@@ -82,7 +102,7 @@ ensure_production_services() {
   local deploy_environment="$1"
   local deploy_host="$2"
 
-  if [[ "$deploy_environment" != "production" || "$deploy_host" != "gpu01" ]]; then
+  if ! is_gpu01_production "$deploy_environment" "$deploy_host"; then
     return
   fi
 
@@ -169,6 +189,8 @@ health_check http://127.0.0.1:8080/health
 health_check https://k-skill-proxy.nomadamas.org/health
 privacy_check http://127.0.0.1:8080/privacy
 privacy_check https://k-skill-proxy.nomadamas.org/privacy
+
+install -m 0755 "$REPO_DIR/scripts/deploy-k-skill-proxy-gpu01.sh" "$APP_DIR/deploy-k-skill-proxy-gpu01.sh"
 
 printf '%s\n' "$target_sha" > "$APP_DIR/deployed-sha"
 trap - ERR

--- a/scripts/deploy-k-skill-proxy-gpu01.sh
+++ b/scripts/deploy-k-skill-proxy-gpu01.sh
@@ -10,6 +10,11 @@ ENV_FILE="${KSKILL_PROXY_ENV_FILE:-$APP_DIR/.env}"
 DEPLOY_ENVIRONMENT="${KSKILL_PROXY_DEPLOY_ENVIRONMENT:-production}"
 DEPLOY_HOST="${KSKILL_PROXY_DEPLOY_HOST:-$(hostname -s)}"
 
+# Services the watchdog keeps alive in production. The 2026-08-29 gpu01 reboot
+# left the tunnel and dashboard stack dead for ~10 days because nothing but
+# this cron ever started them and Restart=on-failure ignores clean SIGTERMs.
+WATCHED_SERVICES="${KSKILL_PROXY_WATCHED_SERVICES:-$SERVICE_NAME k-skill-proxy-tunnel.service k-skill-proxy-loki.service k-skill-proxy-promtail.service k-skill-proxy-grafana.service}"
+
 log() {
   printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
 }
@@ -54,6 +59,39 @@ ensure_gpu01_production_defaults() {
   ensure_env_default "$env_file" "KSKILL_PROXY_TRUST_PROXY_HOPS" "1"
 }
 
+ensure_service_active() {
+  local service="$1"
+
+  if [[ ! "$service" == *.service ]]; then
+    service="$service.service"
+  fi
+
+  if ! systemctl --user list-unit-files "$service" --no-legend 2>/dev/null | grep -q .; then
+    return
+  fi
+
+  if systemctl --user is-active --quiet "$service"; then
+    return
+  fi
+
+  log "Service $service is not active; starting"
+  systemctl --user start "$service"
+}
+
+ensure_production_services() {
+  local deploy_environment="$1"
+  local deploy_host="$2"
+
+  if [[ "$deploy_environment" != "production" || "$deploy_host" != "gpu01" ]]; then
+    return
+  fi
+
+  local service
+  for service in $WATCHED_SERVICES; do
+    ensure_service_active "$service"
+  done
+}
+
 privacy_check() {
   local url="$1"
   local output
@@ -68,6 +106,8 @@ privacy_check() {
 if [[ "${KSKILL_PROXY_DEPLOY_LIB_ONLY:-0}" == "1" ]]; then
   return 0 2>/dev/null || exit 0
 fi
+
+ensure_production_services "$DEPLOY_ENVIRONMENT" "$DEPLOY_HOST"
 
 if [[ ! -d "$REPO_DIR/.git" ]]; then
   log "Cloning source repository"

--- a/scripts/skill-docs.test.js
+++ b/scripts/skill-docs.test.js
@@ -1043,6 +1043,15 @@ test("proxy deployment script and docs stay aligned with gpu01 automation", () =
   assert.match(deployScript, /KSKILL_PROXY_ENV_FILE/);
   assert.match(deployScript, /KSKILL_PROXY_DEPLOY_ENVIRONMENT:-production/);
   assert.match(deployScript, /KSKILL_PROXY_DEPLOY_HOST:-\$\(hostname -s\)/);
+  assert.match(deployScript, /export XDG_RUNTIME_DIR=/);
+  assert.match(deployScript, /export DBUS_SESSION_BUS_ADDRESS=/);
+  assert.match(deployScript, /is_gpu01_production/);
+  assert.match(deployScript, /marker-multi-gpu-server-01/);
+  assert.match(deployScript, /ensure_production_services "\$DEPLOY_ENVIRONMENT" "\$DEPLOY_HOST"/);
+  assert.match(
+    deployScript,
+    /install -m 0755 "\$REPO_DIR\/scripts\/deploy-k-skill-proxy-gpu01\.sh" "\$APP_DIR\/deploy-k-skill-proxy-gpu01\.sh"/,
+  );
   assert.match(deployScript, /ensure_gpu01_production_defaults "\$ENV_FILE" "\$DEPLOY_ENVIRONMENT" "\$DEPLOY_HOST"/);
   assert.match(deployScript, /npm --prefix "\$REPO_DIR" run test --workspace k-skill-proxy/);
   assert.match(deployScript, /tar -C "\$APP_DIR" -czf "\$backup"/);
@@ -1068,6 +1077,18 @@ test("proxy deployment script and docs stay aligned with gpu01 automation", () =
   assert.match(deployDoc, /deployed-sha/);
   assert.match(deployDoc, /KSKILL_PROXY_TRUST_PROXY_HOPS=1/);
   assert.match(deployDoc, /Cloudflare Tunnel/);
+  assert.match(
+    deployDoc,
+    /KSKILL_PROXY_DEPLOY_HOST=gpu01 flock -n \/tmp\/k-skill-proxy-deploy\.lock/,
+  );
+  assert.match(deployDoc, /marker-multi-gpu-server-01/);
+  const setupScript = read(path.join("infra", "k-skill-proxy-dashboard", "setup-gpu01.sh"));
+  assert.match(setupScript, /k-skill-proxy-tunnel\.service/);
+  const proxyUnit = read(
+    path.join("infra", "k-skill-proxy-dashboard", "systemd", "k-skill-proxy.service"),
+  );
+  assert.match(proxyUnit, /^Restart=always$/m);
+  assert.match(proxyUnit, /^StartLimitIntervalSec=0$/m);
   assert.match(packageReadme, /KSKILL_PROXY_TRUST_PROXY_HOPS/);
   assert.match(deployScript, /KSKILL_PROXY_TRUST_PROXY_HOPS/);
 });
@@ -1091,23 +1112,131 @@ test("proxy deployment defaults trust-proxy only for gpu01 production", () => {
     );
 
   const productionEnv = path.join(tmpDir, "production.env");
+  const realHostnameEnv = path.join(tmpDir, "real-hostname.env");
   const stagingEnv = path.join(tmpDir, "staging.env");
   const otherHostEnv = path.join(tmpDir, "other-host.env");
   const explicitEnv = path.join(tmpDir, "explicit.env");
-  for (const envFile of [productionEnv, stagingEnv, otherHostEnv]) {
+  for (const envFile of [productionEnv, realHostnameEnv, stagingEnv, otherHostEnv]) {
     fs.writeFileSync(envFile, "KSKILL_PROXY_RATE_LIMIT_MAX=60\n");
   }
   fs.writeFileSync(explicitEnv, "KSKILL_PROXY_TRUST_PROXY_HOPS=2\n");
 
   runDefault(productionEnv, "production", "gpu01");
+  runDefault(realHostnameEnv, "production", "marker-multi-gpu-server-01");
   runDefault(stagingEnv, "staging", "gpu01");
   runDefault(otherHostEnv, "production", "developer-mac");
   runDefault(explicitEnv, "production", "gpu01");
 
   assert.match(fs.readFileSync(productionEnv, "utf8"), /^KSKILL_PROXY_TRUST_PROXY_HOPS=1$/m);
+  assert.match(fs.readFileSync(realHostnameEnv, "utf8"), /^KSKILL_PROXY_TRUST_PROXY_HOPS=1$/m);
   assert.doesNotMatch(fs.readFileSync(stagingEnv, "utf8"), /KSKILL_PROXY_TRUST_PROXY_HOPS/);
   assert.doesNotMatch(fs.readFileSync(otherHostEnv, "utf8"), /KSKILL_PROXY_TRUST_PROXY_HOPS/);
   assert.match(fs.readFileSync(explicitEnv, "utf8"), /^KSKILL_PROXY_TRUST_PROXY_HOPS=2$/m);
+});
+
+test("proxy deploy watchdog starts dead services on the real gpu01 hostname", () => {
+  const deployScript = path.join(repoRoot, "scripts", "deploy-k-skill-proxy-gpu01.sh");
+  const mockRoot = fs.mkdtempSync(path.join(os.tmpdir(), "k-skill-proxy-watchdog-"));
+  const mockBin = path.join(mockRoot, "bin");
+  fs.mkdirSync(mockBin);
+  fs.writeFileSync(
+    path.join(mockBin, "systemctl"),
+    [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      'STATE_DIR="${MOCK_SYSTEMCTL_STATE:?}"',
+      'echo "$*" >> "$STATE_DIR/calls.log"',
+      'cmd=""',
+      "args=()",
+      "while [[ $# -gt 0 ]]; do",
+      '  case "$1" in',
+      "    --user|--no-legend|--quiet|--no-pager) shift ;;",
+      "    *)",
+      '      if [[ -z "$cmd" ]]; then cmd="$1"; shift',
+      '      else args+=("$1"); shift',
+      "      fi",
+      "      ;;",
+      "  esac",
+      "done",
+      'unit="${args[0]:-}"',
+      'case "$cmd" in',
+      "  list-unit-files)",
+      '    if [[ -f "$STATE_DIR/installed/$unit" ]]; then echo "$unit enabled"; fi',
+      "    exit 0",
+      "    ;;",
+      "  is-active)",
+      '    if [[ -f "$STATE_DIR/active/$unit" ]]; then exit 0; fi',
+      "    exit 3",
+      "    ;;",
+      "  start)",
+      '    mkdir -p "$STATE_DIR/active"',
+      '    touch "$STATE_DIR/active/$unit"',
+      '    echo "$unit" >> "$STATE_DIR/started.log"',
+      "    exit 0",
+      "    ;;",
+      "  *)",
+      '    echo "unexpected: $cmd" >&2',
+      "    exit 99",
+      "    ;;",
+      "esac",
+      "",
+    ].join("\n"),
+    { mode: 0o755 },
+  );
+
+  const runWatchdog = (host, { installed = [], active = [] } = {}) => {
+    const state = fs.mkdtempSync(path.join(mockRoot, "state-"));
+    fs.mkdirSync(path.join(state, "installed"));
+    fs.mkdirSync(path.join(state, "active"));
+    fs.writeFileSync(path.join(state, "calls.log"), "");
+    fs.writeFileSync(path.join(state, "started.log"), "");
+    for (const unit of installed) {
+      fs.writeFileSync(path.join(state, "installed", unit), "");
+    }
+    for (const unit of active) {
+      fs.writeFileSync(path.join(state, "active", unit), "");
+    }
+    childProcess.execFileSync(
+      "bash",
+      [
+        "-c",
+        'export PATH="$1:$PATH"; export MOCK_SYSTEMCTL_STATE="$2"; KSKILL_PROXY_DEPLOY_LIB_ONLY=1 source "$3"; ensure_production_services production "$4"',
+        "bash",
+        mockBin,
+        state,
+        deployScript,
+        host,
+      ],
+      { encoding: "utf8" },
+    );
+    const startedRaw = fs.readFileSync(path.join(state, "started.log"), "utf8").trim();
+    return {
+      started: startedRaw === "" ? [] : startedRaw.split("\n"),
+      calls: fs.readFileSync(path.join(state, "calls.log"), "utf8"),
+    };
+  };
+
+  const watched = [
+    "k-skill-proxy.service",
+    "k-skill-proxy-tunnel.service",
+    "k-skill-proxy-loki.service",
+    "k-skill-proxy-promtail.service",
+    "k-skill-proxy-grafana.service",
+  ];
+
+  assert.deepEqual(runWatchdog("developer-mac", { installed: watched }).started, []);
+  assert.deepEqual(
+    runWatchdog("marker-multi-gpu-server-01", { installed: watched }).started.sort(),
+    [...watched].sort(),
+  );
+  assert.deepEqual(
+    runWatchdog("gpu01", {
+      installed: watched,
+      active: watched.filter((unit) => unit !== "k-skill-proxy-tunnel.service"),
+    }).started,
+    ["k-skill-proxy-tunnel.service"],
+  );
+  assert.deepEqual(runWatchdog("gpu01", { installed: [] }).started, []);
 });
 
 test("kakaotalk-mac skill documents katok archive search usage", () => {


### PR DESCRIPTION
## 문제

2026-08-29 gpu01 재부팅 후 public proxy(Cloudflare 530)와 dashboard(502)가 약 10일간 중단됐습니다. 코드 버그가 아니라, Fastify proxy만 살아남은 이유는 deploy cron이 매 실행마다 `restart`를 때려줬기 때문이고, tunnel과 Loki/Grafana/Promtail은 `Restart=on-failure`라 깨끗한 SIGTERM 후 아무도 다시 시작해주지 않았습니다.

- 상세 사후 분석: #658
- 당시 증거: 로컬 `127.0.0.1:8080/health`는 정상, 공개는 터널 부재로 530 / grafana 부재로 502

## 변경

- `infra/k-skill-proxy-dashboard/systemd/*.service` 3개: `Restart=on-failure` → `always`, `StartLimitIntervalSec=0` 추가
- `systemd/k-skill-proxy-tunnel.service` 신규 커밋: 기존엔 gpu01 호스트에만 존재하던 유닛을 repo로 이동. `Restart=always`, `StartLimitIntervalSec=0`, NFS 부팅 레이스 대응용 `RequiresMountsFor=`(cloudflared 바이너리/config/app 경로)
- `scripts/deploy-k-skill-proxy-gpu01.sh`: `ensure_production_services()` 추가 — SHA 일치로 조기 종료하는 실행 포함 매 cron 실행 시, 설치돼 있는데 active가 아닌 감시 대상 서비스를 start. `KSKILL_PROXY_WATCHED_SERVICES`로 재정의 가능
- `docs/deploy-k-skill-proxy.md`, dashboard README: watchdog와 canonical 유닛 위치 문서화

## 검증

- `bash -n` syntax OK
- watchdog 5개 시나리오 mock 테스트 통과 (non-gpu01 skip / dead→start / active 유지 / unknown skip / bare name `.service` 접미사)
- `node --test scripts/skill-docs.test.js`: 155/155 pass
- 호스트에는 이미 동일 내용이 수동 적용돼 있어 이 PR은 영구화입니다

Closes #658