### PR TITLE
feat(k-skill-cli): version 조회 커맨드 추가

### DIFF
--- a/.changeset/cli-version.md
+++ b/.changeset/cli-version.md
@@ -1,0 +1,5 @@
+---
+"@nomadamas/k-skill": minor
+---
+
+Add `version` / `--version` so the CLI reports its installed package version.

--- a/docs/install.md
+++ b/docs/install.md
@@ -148,6 +148,9 @@ npx -y @nomadamas/k-skill@0 instruct <skill-name>
 명령을 실행하면 `npx`가 호환되는 최신 `0.x` 버전을 가져온다.
 
 ```bash
+# 설치된 CLI 버전
+npx -y @nomadamas/k-skill@0 version
+
 # 배포된 스킬 목록
 npx -y @nomadamas/k-skill@0 list
 
@@ -179,6 +182,7 @@ npm 접근이 제한되거나 반복 호출 비용을 피해야 하면 선택적
 
 ```bash
 npm install -g @nomadamas/k-skill@0
+k-skill version
 k-skill list
 k-skill instruct railway-timetable
 k-skill exec kosis-stats scripts/run_kosis_stats.py -- --help

--- a/packages/k-skill-cli/bin/k-skill.js
+++ b/packages/k-skill-cli/bin/k-skill.js
@@ -10,6 +10,7 @@ const {
 } = require("../src/assemble");
 const { runBundledScript } = require("../src/execute");
 const { detectRuntime } = require("../src/detect");
+const { version } = require("../package.json");
 
 function usage() {
   return [
@@ -23,6 +24,11 @@ function usage() {
     "  path <skill> <file> Print the absolute path of a bundled asset",
     "  files <skill>      Print local paths of the skill's bundled helper files",
     "  list               List bundled skills",
+    "  version            Print the installed CLI version",
+    "",
+    "Options:",
+    "  -h, --help         Show this help",
+    "  -v, -V, --version  Print the installed CLI version",
     "",
     "Runtime detection: DOLSHOI_ACTION_BROKER_URL enables Dolshoi mode;",
     "CLOAKBROWSER_PEEK_TOKEN marks CloakBrowser availability.",
@@ -34,6 +40,11 @@ function main() {
 
   if (!command || command === "--help" || command === "-h") {
     console.log(usage());
+    return 0;
+  }
+
+  if (command === "version" || command === "--version" || command === "-V" || command === "-v") {
+    console.log(version);
     return 0;
   }
 

--- a/packages/k-skill-cli/test/cli.test.js
+++ b/packages/k-skill-cli/test/cli.test.js
@@ -268,4 +268,21 @@ test("CLI binary handles instruct, files, list, and errors", () => {
   assert.equal(help.status, 0);
   assert.match(help.stdout, /exec <skill> <script>/);
   assert.match(help.stdout, /read <skill> <file>/);
+  assert.match(help.stdout, /version/);
+});
+
+test("CLI prints the installed package version", () => {
+  const pkg = JSON.parse(fs.readFileSync(path.join(packageRoot, "package.json"), "utf8"));
+  const run = (args) =>
+    childProcess.spawnSync("node", [binPath, ...args], {
+      encoding: "utf8",
+      env: { ...process.env, DOLSHOI_ACTION_BROKER_URL: "", CLOAKBROWSER_PEEK_TOKEN: "" },
+    });
+
+  for (const args of [["version"], ["--version"], ["-V"], ["-v"]]) {
+    const result = run(args);
+    assert.equal(result.status, 0, args.join(" "));
+    assert.equal(result.stdout, `${pkg.version}\n`);
+    assert.equal(result.stderr, "");
+  }
 });


### PR DESCRIPTION
## 요약

`@nomadamas/k-skill` CLI에 설치된 패키지 버전을 조회하는 경로가 없어서 `k-skill --version`이 unknown command로 떨어졌습니다. `package.json`의 `version`을 그대로 출력하는 커맨드/플래그를 추가합니다.

```bash
k-skill version
k-skill --version
k-skill -V
k-skill -v
```

출력은 npm 스타일로 버전 문자열 한 줄입니다. 테스트는 `package.json`의 현재 `version`을 읽어 CLI stdout과 비교하므로, Changesets 버전 bump에 고정값을 걸지 않습니다.

## 검증

- `node --test packages/k-skill-cli/test/cli.test.js` — 14 pass
- `npm --workspace @nomadamas/k-skill run lint` — pass
- 실제 바이너리: `k-skill version` / `--version` / `-V` / `-v` 모두 `0.8.0` 출력 확인